### PR TITLE
Fixed problem with unused parameters.

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -211,8 +211,8 @@ struct StructVisitor {
 }
 
 impl visit::Visitor<()> for StructVisitor {
-    fn visit_struct_def(&mut self, s: &ast::StructDef, i: ast::Ident, g: &ast::Generics, n: ast::NodeId, e: ()) {
-        visit::walk_struct_def(self, s, i, g, n, e)
+    fn visit_struct_def(&mut self, s: &ast::StructDef, _: ast::Ident, _: &ast::Generics, _: ast::NodeId, e: ()) {
+        visit::walk_struct_def(self, s, e)
     }
     fn visit_struct_field(&mut self, field: &ast::StructField, _: ()) { 
         match field.node.kind {


### PR DESCRIPTION
I pulled down this project just a couple days ago, ran into this error compiling against nightly:

src/ast.rs:215:9: 215:52 error: this function takes 3 parameters but 6 parameters were supplied
src/ast.rs:215         visit::walk_struct_def(self, s, i, g, n, e)
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/ast.rs:215:9: 215:31 error: cannot determine a type for this bounded type parameter: unconstrained type
src/ast.rs:215         visit::walk_struct_def(self, s, i, g, n, e)
                       ^~~~~~~~~~~~~~~~~~~~~~
make: **\* [all] Error 101

Apparently the i,g,n parameters are optional/ignored now. This quick fix got it compiling again.

Thanks for the great work so far with racer! 
