### PR TITLE
Add travis support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 .*
 \#*
 src/scopes
+!.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+before_install:
+  - yes | sudo add-apt-repository ppa:hansjorg/rust
+  - sudo apt-get update
+
+install:
+  - sudo apt-get install rust-nightly
+
+script:
+  - make
+
+branches:
+  only: master


### PR DESCRIPTION
With travis you can check that every commit pushed and every PR sent compiles against the nightly version of Rust.

(You'll need to enable travis support for this repository at [travis-ci.org](https://travis-ci.org/))
