### PR TITLE
Fixed check for environment variable in racer.vim.

### DIFF
--- a/editors/racer.vim
+++ b/editors/racer.vim
@@ -13,7 +13,7 @@ if !exists('g:racer_cmd')
     let g:racer_cmd = "/home/pld/src/rust/racer/bin/racer"
 endif
 
-if !exists($RUST_SRC_PATH)
+if !exists('$RUST_SRC_PATH')
     let $RUST_SRC_PATH="/usr/local/src/rust/src"
 endif
 


### PR DESCRIPTION
Vim's `exists` function expects a string containing an expression, not an expression itself. This fixes the issue with user-defined `RUST_SRC_PATH` being overridden by the plugin anyway.
