### PR TITLE
Don't use commented out scopes.

### DIFF
--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -32,7 +32,8 @@ pub fn find_closing_paren(src:&str, mut pos:uint) -> uint {
 
 
 pub fn scope_start(src:&str, point:uint) -> uint {
-    let s = src.slice(0,point);
+    let maskedSrc = mask_comments(src);
+    let s = maskedSrc.as_slice().slice(0,point);
     let mut pt = point;
     let mut levels = 0i;
     for c in s.chars().rev() {


### PR DESCRIPTION
fixes #42

Let me know if there's a more idiomatic way to do this, I'm new to rust.
