### PR TITLE
Fix enum variant/type name clashes

### DIFF
--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -20,11 +20,11 @@ pub fn slice<'a>(src: &'a str, (begin, end): (uint, uint)) -> &'a str{
 }
 
 enum State {
-    Code,
-    Comment,
-    CommentBlock,
-    String,
-    Finished
+    StateCode,
+    StateComment,
+    StateCommentBlock,
+    StateString,
+    StateFinished
 }
 
 pub struct CodeIndicesIter<'a> {
@@ -39,11 +39,11 @@ impl<'a> Iterator<(uint, uint)> for CodeIndicesIter<'a> {
     #[inline]
     fn next(&mut self) -> Option<(uint, uint)> {
         return match self.state {
-            Code => code(self),
-            Comment => comment(self),
-            CommentBlock  => comment_block(self),
-            String => string(self),
-            Finished => None
+            StateCode => code(self),
+            StateComment => comment(self),
+            StateCommentBlock  => comment_block(self),
+            StateString => string(self),
+            StateFinished => None
         }
     }
 }
@@ -60,14 +60,14 @@ fn code(self_: &mut CodeIndicesIter) -> Option<(uint,uint)> {
         if pos > 0 && src_bytes[pos] == slash && src_bytes[pos-1] == slash {
             self_.start = pos+1;
             self_.pos = pos+1;
-            self_.state = Comment;
+            self_.state = StateComment;
             return Some((start, pos-1));
         }
 
         if pos > 0 && src_bytes[pos] == star && src_bytes[pos-1] == slash {
             self_.start = pos+1;
             self_.pos = pos+1;
-            self_.state = CommentBlock;
+            self_.state = StateCommentBlock;
             self_.nesting_level = 0;
             return Some((start, pos-1));
         }
@@ -75,13 +75,13 @@ fn code(self_: &mut CodeIndicesIter) -> Option<(uint,uint)> {
         if src_bytes[pos] == dblquote {
             self_.start = pos+1;
             self_.pos = pos+1;
-            self_.state = String;
+            self_.state = StateString;
             return Some((start, pos+1)); // include the dblquote in the code
         }
 
         pos += 1;
     }
-    self_.state = Finished;
+    self_.state = StateFinished;
     return Some((start, end));
 }
 
@@ -94,12 +94,12 @@ fn comment(self_: &mut CodeIndicesIter) -> Option<(uint,uint)> {
         if src_bytes[pos] == newline {
             self_.start = pos+1;
             self_.pos = pos+1;
-            self_.state = Code;
+            self_.state = StateCode;
             return code(self_);
         }
         pos += 1;
     }
-    self_.state = Finished;
+    self_.state = StateFinished;
     return Some((start, end));
 }
 
@@ -118,7 +118,7 @@ fn comment_block(self_: &mut CodeIndicesIter) -> Option<(uint,uint)> {
             if self_.nesting_level == 0 {
                 self_.start = pos+1;
                 self_.pos = pos+1;
-                self_.state = Code;
+                self_.state = StateCode;
                 return code(self_);
             } else {
                 self_.nesting_level -= 1;
@@ -126,7 +126,7 @@ fn comment_block(self_: &mut CodeIndicesIter) -> Option<(uint,uint)> {
         }
         pos += 1;
     }
-    self_.state = Finished;
+    self_.state = StateFinished;
     return Some((start, end));
 }
 
@@ -152,18 +152,18 @@ fn string(self_: &mut CodeIndicesIter) -> Option<(uint,uint)> {
         if src_bytes[pos] == dblquote && !escaped(src_bytes, pos) {
             self_.start = pos;   // include the dblquote as code
             self_.pos = pos+1;
-            self_.state = Code;
+            self_.state = StateCode;
             return code(self_);
         }
         pos += 1;
     }
-    self_.state = Finished;
+    self_.state = StateFinished;
     return Some((start, end));
 }
 
 /// Returns indices of chunks of code (minus comments and string contents)
 pub fn code_chunks<'a>(src: &'a str) -> CodeIndicesIter<'a> {
-    CodeIndicesIter { src: src, start: 0, pos: 0, state: Code, nesting_level: 0 }
+    CodeIndicesIter { src: src, start: 0, pos: 0, state: StateCode, nesting_level: 0 }
 }
 
 #[test]

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -45,8 +45,8 @@ pub enum Namespace {
 
 #[deriving(Show)]
 pub enum CompletionType {
-    Field,
-    Path
+    CompleteField,
+    CompletePath
 }
 
 #[deriving(Clone)]
@@ -145,7 +145,7 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: uint) -> vec::M
     let mut out = Vec::new();
 
     match completetype {
-        Path => {
+        CompletePath => {
             let mut v : Vec<&str> = expr.split_str("::").collect();
             let mut global = false;
             if v[0] == "" {      // i.e. starts with '::' e.g. ::std::io::blah
@@ -162,7 +162,7 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: uint) -> vec::M
                 out.push(m);
             }
         },
-        Field => {
+        CompleteField => {
             let context = ast::get_type_of(contextstr.to_string(), filepath, pos);
             debug!("PHIL complete_from_file context is {}", context);
             context.map(|m| {
@@ -190,7 +190,7 @@ pub fn find_definition_(src: &str, filepath: &path::Path, pos: uint) -> Option<M
     debug!("PHIL searching for |{}| |{}| {:?}",contextstr, searchstr, completetype);
 
     return match completetype {
-        Path => {
+        CompletePath => {
             let mut v : Vec<&str> = expr.split_str("::").collect();
             let mut global = false;
             if v[0] == "" {      // i.e. starts with '::' e.g. ::std::io::blah
@@ -206,7 +206,7 @@ pub fn find_definition_(src: &str, filepath: &path::Path, pos: uint) -> Option<M
             return nameres::resolve_path(&path, filepath, pos, 
                                          ExactMatch, BothNamespaces).nth(0);
         },
-        Field => {
+        CompleteField => {
             let context = ast::get_type_of(contextstr.to_string(), filepath, pos);
             debug!("PHIL context is {}",context);
 

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -140,14 +140,14 @@ pub fn split_into_context_and_completion<'a>(s: &'a str) -> (&'a str, &'a str, r
     }
 
     if start != 0 && s_bytes[start-1] == dot {    // field completion
-        return (s.slice_to(start-1), s.slice_from(start), racer::Field);
+        return (s.slice_to(start-1), s.slice_from(start), racer::CompleteField);
     }
 
     if start > 0 && s_bytes[start-1] == colon {  // path completion
-        return (s.slice_to(start-2), s.slice_from(start), racer::Path);
+        return (s.slice_to(start-2), s.slice_from(start), racer::CompletePath);
     }
 
-    return (s.slice_to(start), s.slice_from(start), racer::Path);
+    return (s.slice_to(start), s.slice_from(start), racer::CompletePath);
 }
 
 pub fn get_start_of_search_expr(msrc: &str, point: uint) -> uint {


### PR DESCRIPTION
In rust master enum variants and types share the same namespace now. This
breaks the build due to `enum CompletionType { ..., Path }` vs `struct Path`
and `enum State{ ..., String}` vs `std::string::String`.
