### PR TITLE
Fix RUST_SRC_PATH on Windows

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -22,6 +22,11 @@ use std::{str,vec};
 use std::iter::Iterator;
 use std;
 
+#[cfg(unix)]
+const PATH_SEP: &'static str = ":";
+#[cfg(windows)]
+const PATH_SEP: &'static str = ";";
+
 fn reverse_to_start_of_fn(point: uint, msrc: &str) -> Option<uint> {
     debug!("reverse to start of fn. {}", point);
     scopes::find_stmt_start(msrc, point).map_or(None, |n| {
@@ -227,7 +232,7 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::MoveItems<Matc
     let mut out = Vec::new();
     let srcpaths = std::os::getenv("RUST_SRC_PATH").unwrap_or("".to_string());
     debug!("do_file_search srcpaths {}",srcpaths);
-    let mut v = srcpaths.as_slice().split_str(":").collect::<Vec<_>>();
+    let mut v = srcpaths.as_slice().split_str(PATH_SEP).collect::<Vec<_>>();
     v.push(currentdir.as_str().unwrap());
     debug!("do_file_search v is {}",v);
     for srcpath in v.into_iter() {
@@ -402,7 +407,7 @@ pub fn search_next_scope(mut startpoint: uint, pathseg: &racer::PathSegment,
 
 pub fn get_crate_file(name: &str) -> Option<Path> {
     let srcpaths = std::os::getenv("RUST_SRC_PATH").unwrap();
-    let v = srcpaths.as_slice().split_str(":").collect::<Vec<_>>();
+    let v = srcpaths.as_slice().split_str(PATH_SEP).collect::<Vec<_>>();
     for srcpath in v.into_iter() {
         {
             // try lib<name>/lib.rs, like in the rust source dir
@@ -624,7 +629,7 @@ pub fn search_prelude_file(pathseg: &racer::PathSegment, search_type: SearchType
         None => return out.into_iter()
     };
 
-    let v = srcpaths.as_slice().split_str(":").collect::<Vec<_>>();
+    let v = srcpaths.as_slice().split_str(PATH_SEP).collect::<Vec<_>>();
 
     for srcpath in v.into_iter() {
         let filepath = Path::new(srcpath).join_many(&[Path::new("libstd"), 


### PR DESCRIPTION
Windows uses a semi-colon (`;`) rather than a colon (`:`) for separating paths due to drive letters. Currently, racer changes a path like `'C:\rust\src'` into `['C', '\rust\src']` (see #47). This may work or it may not (I don't know the rules for paths without drive letters, but it does work for some situations). 

I added a check for `#[cfg(windows)]` and `#[cfg(unix)]` to switch between using `;` and `:`. 
