### PR TITLE
Fixed compile-error

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -509,7 +509,7 @@ pub fn search_scope(point: uint, src: &str, pathseg: &racer::PathSegment,
 
         out = out + run_matchers_on_blob(src, point+blobstart, point+blobend, 
                                       searchstr,
-                                      filepath, search_type, local, namespace);
+                                      filepath, search_type, local, namespace).as_slice();
         if let ExactMatch = search_type {
             if !out.is_empty() {
                 return out.into_iter();


### PR DESCRIPTION
Fixed following compile-error which was thrown with nightly build of rust:

```
src\racer\nameres.rs:510:21: 512:79 error: mismatched types: expected `&[racer::Match]`, found `collections::vec::Vec<racer::Match>` (expected &-ptr, found struct collections::vec::Vec)
src\racer\nameres.rs:510         out = out + run_matchers_on_blob(src, point+blobstart, point+blobend,
src\racer\nameres.rs:511                                       searchstr,
src\racer\nameres.rs:512                                       filepath, search_type, local, namespace);
error: aborting due to previous error
```
