### PR TITLE
Fix compilation error for assoc types in the Iterator traits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(macro_rules)]
 #![feature(phase)]
+#![feature(associated_types)]
 #[phase(plugin, link)] extern crate log;
 
 extern crate syntax;

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -35,7 +35,9 @@ pub struct CodeIndicesIter<'a> {
     state: State
 }
 
-impl<'a> Iterator<(uint, uint)> for CodeIndicesIter<'a> {
+impl<'a> Iterator for CodeIndicesIter<'a> {
+    type Item = (uint, uint);
+
     #[inline]
     fn next(&mut self) -> Option<(uint, uint)> {
         return match self.state {

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -19,7 +19,9 @@ pub struct StmtIndicesIter<'a> {
     enddelim: u8
 }
 
-impl<'a> Iterator<(uint, uint)> for StmtIndicesIter<'a> {
+impl<'a> Iterator for StmtIndicesIter<'a> {
+    type Item = (uint, uint);
+
     #[inline]
     fn next(&mut self) -> Option<(uint, uint)> {
         let semicolon: u8 = ";".as_bytes()[0];


### PR DESCRIPTION
This error is the following:

```
$ make
rustc -O -o bin/racer src/main.rs
src/racer/codeiter.rs:22:10: 22:32 error: wrong number of type arguments: expected 0, found 1
src/racer/codeiter.rs:22 impl<'a> Iterator<(uint, uint)> for StmtIndicesIter<'a> {
                                  ^~~~~~~~~~~~~~~~~~~~~~
```

This is caused by <https://github.com/rust-lang/rust/pull/20441>.