### PR TITLE
Make racer friendly to vim package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,22 @@
 
 ## Vim integration
 
-1. Copy racer/editors/racer.vim into your .vim/plugin directory
+1. Install using Pathogen, Vundle or NeoBundle. Or, copy racer/plugin/racer.vim into your .vim/plugin directory.
+
+  Vundle users:
+  ```
+  Vundle 'phildawes/racer'
+  ```
+
+  NeoBundle users:
+  ```
+  NeoBundle 'phildawes/racer', {
+  \   'build' : {
+  \     'mac': 'make',
+  \     'unix': 'make',
+  \   }
+  \ }
+  ```
 
 2. Add g:racer_cmd and $RUST_SRC_PATH variables to your .vimrc. Also it's worth turning on 'hidden' mode for buffers otherwise you need to save the current buffer every time you do a goto-definition. E.g.:
 

--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -10,7 +10,11 @@
 
 
 if !exists('g:racer_cmd')
-    let g:racer_cmd = "/home/pld/src/rust/racer/bin/racer"
+    let g:racer_cmd = escape(expand('<sfile>:p:h'), '\') . '/../bin/racer'
+
+    if !(filereadable(g:racer_cmd))
+      echohl WarningMsg | echomsg "No racer executable present in " . g:racer_cmd
+    endif
 endif
 
 if !exists('$RUST_SRC_PATH')


### PR DESCRIPTION
Move racer.vim to expected location for pathogen, vundle, and neobundle.

Update README with instructions for using Vundle and NeoBundle