### PR TITLE
Change all slice methods to [..] 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ pub mod racer;
 #[cfg(not(test))]
 fn match_fn(m:Match) {
     let (linenum, charnum) = scopes::point_to_coords_from_file(&m.filepath, m.point).unwrap();
-    if m.matchstr.as_slice() == "" {
+    if m.matchstr == "" {
         panic!("MATCHSTR is empty - waddup?");
     }
     println!("MATCH {},{},{},{},{:?},{}", m.matchstr,
@@ -39,7 +39,7 @@ fn complete() {
         std::os::set_exit_status(1);
         return;
     }
-    match std::os::args().as_slice()[2].as_slice().parse::<usize>() {
+    match std::os::args()[2].parse::<usize>() {
         Some(linenum) => {
             // input: linenum, colnum, fname
             if args.len() < 5 {
@@ -48,13 +48,13 @@ fn complete() {
                 std::os::set_exit_status(1);
                 return;
             }
-            let charnum = std::os::args().as_slice()[3].as_slice().parse::<usize>().unwrap();
-            let fname = args.as_slice()[4].as_slice();
+            let charnum = std::os::args()[3].parse::<usize>().unwrap();
+            let fname = &args[4][];
             let fpath = Path::new(fname);
             let src = racer::load_file(&fpath);
-            let line = getline(&fpath, linenum);
-            let (start, pos) = racer::util::expand_ident(line.as_slice(), charnum);
-            println!("PREFIX {},{},{}", start, pos, line.as_slice().slice(start, pos));
+            let line = &*getline(&fpath, linenum);
+            let (start, pos) = racer::util::expand_ident(line, charnum);
+            println!("PREFIX {},{},{}", start, pos, &line[start..pos]);
 
             let point = scopes::coords_to_point(&*src, linenum, charnum);
             for m in racer::complete_from_file(&*src, &fpath, point) {
@@ -63,15 +63,15 @@ fn complete() {
         }
         None => {
             // input: a command line string passed in
-            let arg = args.as_slice()[2].as_slice();
+            let arg = &args[2][];
             let it = arg.split_str("::");
             let p : Vec<&str> = it.collect();
 
-            for m in do_file_search(p.as_slice()[0], &Path::new(".")) {
+            for m in do_file_search(p[0], &Path::new(".")) {
                 if p.len() == 1 {
                     match_fn(m);
                 } else {
-                    for m in do_external_search(p.slice_from(1), &m.filepath, m.point, racer::SearchType::StartsWith, racer::Namespace::BothNamespaces) {
+                    for m in do_external_search(&p[1..], &m.filepath, m.point, racer::SearchType::StartsWith, racer::Namespace::BothNamespaces) {
                         match_fn(m);
                     }
                 }
@@ -82,38 +82,36 @@ fn complete() {
 
 #[cfg(not(test))]
 fn prefix() {
-    let args_ = std::os::args();
-    let args = args_.as_slice();
+    let args = std::os::args();
     if args.len() < 5 {
         println!("Provide more arguments!");
         print_usage();
         std::os::set_exit_status(1);
         return;
     }
-    let linenum = args[2].as_slice().parse::<usize>().unwrap();
-    let charnum = args[3].as_slice().parse::<usize>().unwrap();
-    let fname = args[4].as_slice();
+    let linenum = args[2].parse::<usize>().unwrap();
+    let charnum = args[3].parse::<usize>().unwrap();
+    let fname = &args[4][];
 
     // print the start, end, and the identifier prefix being matched
     let path = Path::new(fname);
-    let line = getline(&path, linenum);
-    let (start, pos) = racer::util::expand_ident(line.as_slice(), charnum);
-    println!("PREFIX {},{},{}", start, pos, line.as_slice().slice(start, pos));
+    let line = &*getline(&path, linenum);
+    let (start, pos) = racer::util::expand_ident(line, charnum);
+    println!("PREFIX {},{},{}", start, pos, &line[start..pos]);
 }
 
 #[cfg(not(test))]
 fn find_definition() {
-    let args_ = std::os::args();
-    let args = args_.as_slice();
+    let args = std::os::args();
     if args.len() < 5 {
         println!("Provide more arguments!");
         print_usage();
         std::os::set_exit_status(1);
         return;
     }
-    let linenum = args[2].as_slice().parse::<usize>().unwrap();
-    let charnum = args[3].as_slice().parse::<usize>().unwrap();
-    let fname = args[4].as_slice();
+    let linenum = args[2].parse::<usize>().unwrap();
+    let charnum = args[3].parse::<usize>().unwrap();
+    let fname = &args[4][];
     let fpath = Path::new(fname);
     let src = racer::load_file(&fpath);
     let pos = scopes::coords_to_point(&*src, linenum, charnum);
@@ -123,7 +121,7 @@ fn find_definition() {
 
 #[cfg(not(test))]
 fn print_usage() {
-    let program = std::os::args().as_slice()[0].clone();
+    let program = std::os::args()[0].clone();
     println!("usage: {} complete linenum charnum fname", program);
     println!("or:    {} find-definition linenum charnum fname", program);
     println!("or:    {} complete fullyqualifiedname   (e.g. std::io::)",program);
@@ -139,8 +137,7 @@ fn main() {
         return;
     }
 
-    let args_ = std::os::args();
-    let args = args_.as_slice();
+    let args = std::os::args();
 
     if args.len() == 1 {
         print_usage();
@@ -148,8 +145,8 @@ fn main() {
         return;
     }
 
-    let command = args[1].as_slice();
-    match command.as_slice() {
+    let command = &args[1][];
+    match command {
         "prefix" => prefix(),
         "complete" => complete(),
         "find-definition" => find_definition(),

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -1,10 +1,10 @@
 //#[cfg(test)] use racer::testutils::{rejustify, slice};
 
 pub fn rejustify(src: &str) -> String {
-    let s = src.slice_from(1); // remove the newline
+    let s = &src[1..]; // remove the newline
     let mut sb = String::new();
     for l in s.lines() {
-        let tabless = l.slice_from(4);
+        let tabless = &l[4..];
         sb.push_str(tabless); 
         if tabless.len() != 0 { 
             sb.push_str("\n");
@@ -16,7 +16,7 @@ pub fn rejustify(src: &str) -> String {
 }
 
 pub fn slice<'a>(src: &'a str, (begin, end): (usize, usize)) -> &'a str{
-    return src.slice(begin, end);
+    return &src[begin..end];
 }
 
 enum State {
@@ -170,102 +170,100 @@ pub fn code_chunks<'a>(src: &'a str) -> CodeIndicesIter<'a> {
 
 #[test]
 fn removes_a_comment() {
-    let src = rejustify("
+    let src = &rejustify("
     this is some code // this is a comment
     some more code
-    ");
-    let mut it = code_chunks(src.as_slice());
-    assert_eq!("this is some code ", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("some more code", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = code_chunks(src);
+    assert_eq!("this is some code ", slice(src, it.next().unwrap()));
+    assert_eq!("some more code", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn removes_string_contents() {
-    let src = rejustify("
+    let src = &rejustify("
     this is some code \"this is a string\" more code
-    ");
-    let mut it = code_chunks(src.as_slice());
-    assert_eq!("this is some code \"", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("\" more code", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = code_chunks(src);
+    assert_eq!("this is some code \"", slice(src, it.next().unwrap()));
+    assert_eq!("\" more code", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn removes_string_contents_with_a_comment_in_it() {
-    let src = rejustify("
+    let src = &rejustify("
     this is some code \"string with a // fake comment \" more code
-    ");
-    let mut it = code_chunks(src.as_slice());
-    assert_eq!("this is some code \"", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("\" more code", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = code_chunks(src);
+    assert_eq!("this is some code \"", slice(src, it.next().unwrap()));
+    assert_eq!("\" more code", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn removes_a_comment_with_a_dbl_quote_in_it() {
-    let src = rejustify("
+    let src = &rejustify("
     this is some code // comment with \" double quote
     some more code
-    ");
-    let mut it = code_chunks(src.as_slice());
-    assert_eq!("this is some code ", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("some more code", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = code_chunks(src);
+    assert_eq!("this is some code ", slice(src, it.next().unwrap()));
+    assert_eq!("some more code", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn removes_multiline_comment() {
-    let src = rejustify("
+    let src = &rejustify("
     this is some code /* this is a
     \"multiline\" comment */some more code
-    ");
-    let mut it = code_chunks(src.as_slice());
-    assert_eq!("this is some code ", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("some more code", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = code_chunks(src);
+    assert_eq!("this is some code ", slice(src, it.next().unwrap()));
+    assert_eq!("some more code", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn handles_nesting_of_block_comments() {
-    let src = rejustify("
+    let src = &rejustify("
     this is some code /* nested /* block */ comment */ some more code
-    ");
-    let mut it = code_chunks(src.as_slice());
-    assert_eq!("this is some code ", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!(" some more code", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = code_chunks(src);
+    assert_eq!("this is some code ", slice(src, it.next().unwrap()));
+    assert_eq!(" some more code", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn removes_string_with_escaped_dblquote_in_it() {
-    let src = rejustify("
+    let src = &rejustify("
     this is some code \"string with a \\\" escaped dblquote fake comment \" more code
-    ");
+    ")[];
 
-    let mut it = code_chunks(src.as_slice());
-    assert_eq!("this is some code \"", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("\" more code", slice(src.as_slice(), it.next().unwrap()));
+    let mut it = code_chunks(src);
+    assert_eq!("this is some code \"", slice(src, it.next().unwrap()));
+    assert_eq!("\" more code", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn removes_string_with_escaped_slash_before_dblquote_in_it() {
-    let src = rejustify("
+    let src = &rejustify("
     this is some code \"string with an escaped slash, so dbl quote does end the string after all \\\\\" more code
-    ");
+    ")[];
 
-    let mut it = code_chunks(src.as_slice());
-    assert_eq!("this is some code \"", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("\" more code", slice(src.as_slice(), it.next().unwrap()));
+    let mut it = code_chunks(src);
+    assert_eq!("this is some code \"", slice(src, it.next().unwrap()));
+    assert_eq!("\" more code", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn handles_tricky_bit_from_str_rs() {
-    let src = rejustify("
+    let src = &rejustify("
         before(\"\\\\\'\\\\\\\"\\\\\\\\\");
         more_code(\" skip me \")
-    ");
-
-    let src = src.as_slice();
+    ")[];
 
     for (start,end) in code_chunks(src) {
-        println!("BLOB |{}|",src.slice(start,end));
-        if src.slice(start,end).contains("skip me") {
-            panic!("{}", src.slice(start,end));
+        println!("BLOB |{}|",&src[start..end]);
+        if (&src[start..end]).contains("skip me") {
+            panic!("{}", &src[start..end]);
         }
     }
 }

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -157,7 +157,7 @@ fn is_a_use_stmt(src: &str, start: usize, pos: usize) -> bool {
     let whitespace = " {\t\r\n".as_bytes();
     (pos > 3 && &src_bytes[start..start+3] == "use".as_bytes() && 
      whitespace.contains(&src_bytes[start+3])) || 
-        (pos > 7 && src_bytes.slice(start, start+7) == "pub use".as_bytes() &&
+        (pos > 7 && &src_bytes[start..(start+7)] == "pub use".as_bytes() &&
                       whitespace.contains(&src_bytes[start+7]))
 }
 

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -84,7 +84,7 @@ impl<'a> Iterator for StmtIndicesIter<'a> {
             // if the statement starts with 'macro_rules!' then we're in a macro
             // We need to know this because a closeparen can terminate a macro
             if (self.end - self.pos) > 12 && 
-               self.src.slice(self.pos, self.pos+12) == "macro_rules!" {
+                &self.src[self.pos..self.pos+12] == "macro_rules!" {
                 self.is_macro = true;
             }
 
@@ -155,7 +155,7 @@ impl<'a> Iterator for StmtIndicesIter<'a> {
 fn is_a_use_stmt(src: &str, start: usize, pos: usize) -> bool {
     let src_bytes = src.as_bytes();
     let whitespace = " {\t\r\n".as_bytes();
-    (pos > 3 && src_bytes.slice(start, start+3) == "use".as_bytes() && 
+    (pos > 3 && &src_bytes[start..start+3] == "use".as_bytes() && 
      whitespace.contains(&src_bytes[start+3])) || 
         (pos > 7 && src_bytes.slice(start, start+7) == "pub use".as_bytes() &&
                       whitespace.contains(&src_bytes[start+7]))
@@ -171,53 +171,53 @@ pub fn iter_stmts<'a>(src: &'a str) -> StmtIndicesIter<'a> {
 
 #[test]
 fn iterates_single_use_stmts() {
-    let src = rejustify("
+    let src = &rejustify("
     use std::Foo; // a comment
     use std::Bar;
-    ");
-    let mut it = iter_stmts(src.as_slice());
-    assert_eq!("use std::Foo;", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("use std::Bar;", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = iter_stmts(src);
+    assert_eq!("use std::Foo;", slice(src, it.next().unwrap()));
+    assert_eq!("use std::Bar;", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn iterates_use_stmt_over_two_lines() {
-    let src = rejustify("
+    let src = &rejustify("
     use std::{Foo,
               Bar}; // a comment
-    ");
-    let mut it = iter_stmts(src.as_slice());
+    ")[];
+    let mut it = iter_stmts(src);
     assert_eq!("use std::{Foo,
-          Bar};", slice(src.as_slice(), it.next().unwrap()));
+          Bar};", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn iterates_use_stmt_without_the_prefix() {
-    let src = rejustify("
+    let src = &rejustify("
     pub use {Foo,
               Bar}; // this is also legit apparently
-    ");
-    let mut it = iter_stmts(src.as_slice());
+    ")[];
+    let mut it = iter_stmts(src);
     assert_eq!("pub use {Foo,
-          Bar};", slice(src.as_slice(), it.next().unwrap()));
+          Bar};", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn iterates_while_stmt() {
-    let src = rejustify("
+    let src = &rejustify("
     while self.pos < 3 { }
-    ");
-    let mut it = iter_stmts(src.as_slice());
-    assert_eq!("while self.pos < 3 { }", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = iter_stmts(src);
+    assert_eq!("while self.pos < 3 { }", slice(src, it.next().unwrap()));
 }
 
 #[test]
 fn iterates_lambda_arg() {
-    let src = rejustify("
+    let src = &rejustify("
     myfn(|n|{});
-    ");
-    let mut it = iter_stmts(src.as_slice());
-    assert_eq!("myfn(|n|{});", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = iter_stmts(src);
+    assert_eq!("myfn(|n|{});", slice(src, it.next().unwrap()));
 }
 
 #[test]
@@ -229,12 +229,12 @@ fn iterates_macro() {
     )
     mod bar;
     ";
-    let mut it = iter_stmts(src.as_slice());
-    assert_eq!("mod foo;", slice(src.as_slice(), it.next().unwrap()));
+    let mut it = iter_stmts(src);
+    assert_eq!("mod foo;", slice(src, it.next().unwrap()));
     assert_eq!("macro_rules! otry(
         ($e:expr) => (match $e { Some(e) => e, None => return })
-    )", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("mod bar;", slice(src.as_slice(), it.next().unwrap()));
+    )", slice(src, it.next().unwrap()));
+    assert_eq!("mod bar;", slice(src, it.next().unwrap()));
 }
 
 #[test]
@@ -244,10 +244,10 @@ fn iterates_macro_invocation() {
     local_data_key!(local_stdout: Box<Writer + Send>)  // no ';'
     mod bar;
     ";
-    let mut it = iter_stmts(src.as_slice());
-    assert_eq!("mod foo;", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("local_data_key!(local_stdout: Box<Writer + Send>)", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("mod bar;", slice(src.as_slice(), it.next().unwrap()));
+    let mut it = iter_stmts(src);
+    assert_eq!("mod foo;", slice(src, it.next().unwrap()));
+    assert_eq!("local_data_key!(local_stdout: Box<Writer + Send>)", slice(src, it.next().unwrap()));
+    assert_eq!("mod bar;", slice(src, it.next().unwrap()));
 }
 
 
@@ -272,7 +272,7 @@ fn iterates_inner_scope() {
     }
     ";
 
-    let scope = src.as_slice().slice_from(25);
+    let scope = &src[25..];
     let mut it = iter_stmts(scope);
 
     assert_eq!("let a = 35;", slice(scope, it.next().unwrap()));
@@ -282,13 +282,13 @@ fn iterates_inner_scope() {
 
 #[test]
 fn iterates_module_attribute() {
-    let src = rejustify("
+    let src = &rejustify("
     #![license = \"BSD\"]
     #[test]
-    ");
-    let mut it = iter_stmts(src.as_slice());
-    assert_eq!("#![license = \"BSD\"]", slice(src.as_slice(), it.next().unwrap()));
-    assert_eq!("#[test]", slice(src.as_slice(), it.next().unwrap()));
+    ")[];
+    let mut it = iter_stmts(src);
+    assert_eq!("#![license = \"BSD\"]", slice(src, it.next().unwrap()));
+    assert_eq!("#[test]", slice(src, it.next().unwrap()));
 }
 
 #[test]

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -201,7 +201,7 @@ pub fn load_file(filepath: &path::Path) -> String {
     let rawbytes = BufferedReader::new(File::open(filepath)).read_to_end().unwrap();
 
     // skip BOF bytes, if present
-    if rawbytes.slice(0,3) == [0xEF, 0xBB, 0xBF] {
+    if rawbytes[0..3] == [0xEF, 0xBB, 0xBF][] {
         let mut it = rawbytes.into_iter();
         it.next(); it.next(); it.next();
         return String::from_utf8(it.collect::<Vec<_>>()).unwrap();
@@ -212,7 +212,7 @@ pub fn load_file(filepath: &path::Path) -> String {
 
 pub fn load_file_and_mask_comments(filepath: &path::Path) -> String {
     let filetxt = BufferedReader::new(File::open(filepath)).read_to_end().unwrap();
-    let src = str::from_utf8(filetxt.as_slice()).unwrap();
+    let src = str::from_utf8(&filetxt[]).unwrap();
     let msrc = scopes::mask_comments(src);
     return msrc;
 }
@@ -220,7 +220,7 @@ pub fn load_file_and_mask_comments(filepath: &path::Path) -> String {
 pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize) -> vec::IntoIter<Match> {
 
     let start = scopes::get_start_of_search_expr(src, pos);
-    let expr = src.slice(start,pos);
+    let expr = &src[start..pos];
 
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
 
@@ -274,7 +274,7 @@ pub fn find_definition(src: &str, filepath: &path::Path, pos: usize) -> Option<M
 
 pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize) -> Option<Match> {
     let (start, end) = scopes::expand_search_expr(src, pos);
-    let expr = src.slice(start,end);
+    let expr = &src[start..end];
 
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
 

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -33,7 +33,7 @@ pub fn find_closing_paren(src:&str, mut pos:usize) -> usize {
 
 pub fn scope_start(src:&str, point:usize) -> usize {
     let masked_src = mask_comments(src);
-    let s = masked_src.as_slice().slice(0,point);
+    let s = &masked_src[..point];
     let mut pt = point;
     let mut levels = 0i32;
     for c in s.chars().rev() {
@@ -55,7 +55,7 @@ pub fn scope_start(src:&str, point:usize) -> usize {
 pub fn find_stmt_start(msrc: &str, point: usize) -> Option<usize> {
     // iterate the scope to find the start of the statement
     let scopestart = scope_start(msrc, point);
-    for (start, end) in codeiter::iter_stmts(msrc.slice_from(scopestart)) {
+    for (start, end) in codeiter::iter_stmts(&msrc[scopestart..]) {
         if (scopestart + end) > point {
             return Some(scopestart+start);
         }
@@ -72,14 +72,14 @@ pub fn get_local_module_path(msrc: &str, point: usize) -> Vec<String> {
 fn get_local_module_path_(msrc: &str, point: usize, out: &mut Vec<String>) {
     for (start, end) in codeiter::iter_stmts(msrc) {
         if start < point && end > point {
-            let blob = msrc.slice(start, end);
+            let blob = &msrc[start..end];
             if blob.starts_with("pub mod "){
                 let p = typeinf::generate_skeleton_for_parsing(blob);
                 ast::parse_mod(p).name.map(|name|{
 
                     let newstart = blob.find_str("{").unwrap() + 1;
                     out.push(name);
-                    get_local_module_path_(blob.slice_from(newstart), 
+                    get_local_module_path_(&blob[newstart..], 
                                        point - start - newstart, out);
                 });
             }
@@ -89,9 +89,9 @@ fn get_local_module_path_(msrc: &str, point: usize, out: &mut Vec<String>) {
 
 pub fn find_impl_start(msrc: &str, point: usize, scopestart: usize) -> Option<usize> {
 
-    for (start, end) in codeiter::iter_stmts(msrc.slice_from(scopestart)) {
+    for (start, end) in codeiter::iter_stmts(&msrc[scopestart..]) {
         if (scopestart + end) > point {
-            let blob = msrc.slice_from(scopestart + start);
+            let blob = &msrc[(scopestart + start)..];
             // TODO:: the following is a bit weak at matching traits. make this better
             if blob.starts_with("impl") || 
                 blob.starts_with("trait") || blob.starts_with("pub trait") {
@@ -116,12 +116,12 @@ fn finds_subnested_module() {
     }";
     let point = coords_to_point(src, 4, 12);
     let v = get_local_module_path(src, point);
-    assert_eq!("foo", v[0].as_slice());
-    assert_eq!("bar", v[1].as_slice());
+    assert_eq!("foo", &v[0][]);
+    assert_eq!("bar", &v[1][]);
 
     let point = coords_to_point(src, 2, 8);
     let v = get_local_module_path(src, point);
-    assert_eq!("foo", v[0].as_slice());
+    assert_eq!("foo", &v[0][]);
 }
 
 
@@ -140,14 +140,14 @@ pub fn split_into_context_and_completion<'a>(s: &'a str) -> (&'a str, &'a str, r
     }
 
     if start != 0 && s_bytes[start-1] == dot {    // field completion
-        return (s.slice_to(start-1), s.slice_from(start), racer::CompletionType::CompleteField);
+        return (&s[..(start-1)], &s[start..], racer::CompletionType::CompleteField);
     }
 
     if start > 0 && s_bytes[start-1] == colon {  // path completion
-        return (s.slice_to(start-2), s.slice_from(start), racer::CompletionType::CompletePath);
+        return (&s[..(start-2)], &s[start..], racer::CompletionType::CompletePath);
     }
 
-    return (s.slice_to(start), s.slice_from(start), racer::CompletionType::CompletePath);
+    (&s[..start], &s[start..], racer::CompletionType::CompletePath)
 }
 
 pub fn get_start_of_search_expr(msrc: &str, point: usize) -> usize {
@@ -255,7 +255,7 @@ pub fn mask_comments(src: &str) -> String {
         for _ in ::std::iter::range(prev, start) {
             result.push_str(space);
         }
-        result.push_str(src.slice(start,end));
+        result.push_str(&src[start..end]);
         prev = end;
     }
     return result;
@@ -299,7 +299,7 @@ pub fn end_of_next_scope<'a>(src: &'a str) -> &'a str {
             level += 1;
         }
     }
-    return src.slice_to(end);
+    &src[..end]
 }
 
 pub fn coords_to_point(src: &str, mut linenum: usize, col: usize) -> usize {
@@ -397,7 +397,7 @@ some more
     assert!(src.as_bytes()[5] == r.as_bytes()[5]);
     // characters in the comments are masked
     let commentoffset = coords_to_point(src,3,23);
-    assert!(r.as_slice().char_at(commentoffset) == ' ');
+    assert!(&r[].char_at(commentoffset) == ' ');
     assert!(src.as_bytes()[commentoffset] != r.as_bytes()[commentoffset]);
     // characters afterwards are the same
     assert!(src.as_bytes()[src.len()-3] == r.as_bytes()[src.len()-3]);

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -397,7 +397,7 @@ some more
     assert!(src.as_bytes()[5] == r.as_bytes()[5]);
     // characters in the comments are masked
     let commentoffset = coords_to_point(src,3,23);
-    assert!(&r[].char_at(commentoffset) == ' ');
+    assert!((&r[]).char_at(commentoffset) == ' ');
     assert!(src.as_bytes()[commentoffset] != r.as_bytes()[commentoffset]);
     // characters afterwards are the same
     assert!(src.as_bytes()[src.len()-3] == r.as_bytes()[src.len()-3]);

--- a/src/racer/test.rs
+++ b/src/racer/test.rs
@@ -9,7 +9,7 @@ fn tmpname() -> Path {
     let taskname = thread.name().unwrap();
     let s = taskname.replace("::","_"); 
     let mut p = String::from_str("tmpfile.");
-    p.push_str(s.as_slice());
+    p.push_str(&s[]);
     Path::new(p)
 }
 
@@ -577,7 +577,7 @@ fn differentiates_type_and_value_namespaces() {
     remove_file(&path);
     println!("{}",got.matchstr);
     println!("{:?}",got.mtype);
-    assert_eq!("new", got.matchstr.as_slice());
+    assert_eq!("new", &got.matchstr[]);
 }
 
 #[test]
@@ -597,7 +597,7 @@ fn follows_self_to_method() {
     let pos = scopes::coords_to_point(src, 8, 20);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("method", got.matchstr.as_slice());    
+    assert_eq!("method", &got.matchstr[]);    
 }
 
 #[test]
@@ -618,7 +618,7 @@ fn follows_self_to_method_when_call_on_new_line() {
     let pos = scopes::coords_to_point(src, 9, 20);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("method", got.matchstr.as_slice());    
+    assert_eq!("method", &got.matchstr[]);    
 }
 
 
@@ -637,7 +637,7 @@ fn follows_self_to_trait_method() {
     let pos = scopes::coords_to_point(src, 6, 20);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("method", got.matchstr.as_slice());    
+    assert_eq!("method", &got.matchstr[]);    
 }
 
 #[test]
@@ -659,7 +659,7 @@ fn finds_trait_method() {
     let pos = scopes::coords_to_point(src, 10, 22);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("trait_method", got.matchstr.as_slice());
+    assert_eq!("trait_method", &got.matchstr[]);
 }
 
 
@@ -680,7 +680,7 @@ fn finds_field_type() {
     let pos = scopes::coords_to_point(src, 9, 16);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 #[test]
@@ -698,7 +698,7 @@ fn finds_a_generic_retval_from_a_function() {
     let pos = scopes::coords_to_point(src, 7, 24);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 #[test]
@@ -721,7 +721,7 @@ fn handles_an_enum_option_style_return_type() {
     let pos = scopes::coords_to_point(src, 12, 18);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 #[test]
@@ -735,7 +735,7 @@ fn finds_definition_of_const() {
     let pos = scopes::coords_to_point(src, 3, 7);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("MYCONST", got.matchstr.as_slice());
+    assert_eq!("MYCONST", &got.matchstr[]);
 }
 
 #[test]
@@ -749,7 +749,7 @@ fn finds_definition_of_static() {
     let pos = scopes::coords_to_point(src, 3, 7);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("MYSTATIC", got.matchstr.as_slice());
+    assert_eq!("MYSTATIC", &got.matchstr[]);
 }
 
 #[test]
@@ -763,7 +763,7 @@ fn handles_dotdot_before_searchstr() {
     let pos = scopes::coords_to_point(src, 3, 22);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("MYLEN", got.matchstr.as_slice());
+    assert_eq!("MYLEN", &got.matchstr[]);
 }
 
 
@@ -778,7 +778,7 @@ fn finds_definition_of_lambda_argument() {
     let pos = scopes::coords_to_point(src, 3, 12);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("a", got.matchstr.as_slice());
+    assert_eq!("a", &got.matchstr[]);
 }
 
 #[test]
@@ -792,7 +792,7 @@ fn finds_definition_of_let_tuple() {
     let pos = scopes::coords_to_point(src, 3, 4);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("a", got.matchstr.as_slice());
+    assert_eq!("a", &got.matchstr[]);
 }
 
 #[test]
@@ -807,7 +807,7 @@ fn finds_type_of_tuple_member_via_let_type() {
     let pos = scopes::coords_to_point(src, 4, 11);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 
@@ -823,7 +823,7 @@ fn finds_type_of_tuple_member_via_let_expr() {
     let pos = scopes::coords_to_point(src, 4, 11);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 
@@ -840,7 +840,7 @@ fn finds_type_of_tuple_member_via_fn_retval() {
     let pos = scopes::coords_to_point(src, 5, 11);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 
@@ -857,7 +857,7 @@ fn finds_type_of_tuple_member_in_fn_arg() {
     let pos = scopes::coords_to_point(src, 4, 11);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 #[test]
@@ -871,7 +871,7 @@ fn finds_namespaced_enum_variant() {
     let pos = scopes::coords_to_point(src, 3, 14);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("MyVariant", got.matchstr.as_slice());
+    assert_eq!("MyVariant", &got.matchstr[]);
 }
 
 #[test]
@@ -886,7 +886,7 @@ fn finds_glob_imported_enum_variant() {
     let pos = scopes::coords_to_point(src, 4, 8);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("MyVariant", got.matchstr.as_slice());
+    assert_eq!("MyVariant", &got.matchstr[]);
 }
 
 #[test]
@@ -904,7 +904,7 @@ fn uses_generic_arg_to_resolve_trait_method() {
     let pos = scopes::coords_to_point(src, 6, 19);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("trait_method", got.matchstr.as_slice());
+    assert_eq!("trait_method", &got.matchstr[]);
 }
 
 #[test]
@@ -920,7 +920,7 @@ fn destructures_a_tuplestruct() {
     let pos = scopes::coords_to_point(src, 5, 10);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 #[test]
@@ -937,7 +937,7 @@ fn destructures_a_tuplestruct_with_generic_arg() {
     let pos = scopes::coords_to_point(src, 6, 10);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 
@@ -1010,7 +1010,7 @@ fn handles_if_let() {
     let pos = scopes::coords_to_point(src, 9, 13);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 #[test]
@@ -1031,7 +1031,7 @@ fn handles_if_let_as_expression() {
     let pos = scopes::coords_to_point(src, 9, 13);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 
@@ -1046,7 +1046,7 @@ fn finds_match_arm_var() {
     let pos = scopes::coords_to_point(src, 3, 18);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("a", got.matchstr.as_slice());
+    assert_eq!("a", &got.matchstr[]);
 }
 
 #[test]
@@ -1060,7 +1060,7 @@ fn finds_match_arm_var_in_scope() {
     let pos = scopes::coords_to_point(src, 3, 20);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("a", got.matchstr.as_slice());
+    assert_eq!("a", &got.matchstr[]);
 }
 
 #[test]
@@ -1080,7 +1080,7 @@ fn finds_match_arm_var_with_nested_match() {
     let pos = scopes::coords_to_point(src, 8, 15);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("a", got.matchstr.as_slice());
+    assert_eq!("a", &got.matchstr[]);
 }
 
 #[test]
@@ -1100,7 +1100,7 @@ fn gets_type_via_match_arm() {
     let pos = scopes::coords_to_point(src, 9, 38);
     let got = find_definition(src, &path, pos).unwrap();
     remove_file(&path);
-    assert_eq!("subfield", got.matchstr.as_slice());
+    assert_eq!("subfield", &got.matchstr[]);
 }
 
 

--- a/src/racer/testutils.rs
+++ b/src/racer/testutils.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 pub fn rejustify(src: &str) -> String {
-    let s = src.slice_from(1); // remove the newline
+    let s = &src[1..]; // remove the newline
     let mut sb = String::new();
     for l in s.lines() {
-        let tabless = l.slice_from(4);
+        let tabless = &l[4..];
         sb.push_str(tabless); 
         if tabless.len() != 0 { 
             sb.push_str("\n");
@@ -16,5 +16,5 @@ pub fn rejustify(src: &str) -> String {
 
 #[cfg(test)]
 pub fn slice<'a>(src: &'a str, (begin, end): (usize, usize)) -> &'a str{
-    return src.slice(begin, end);
+    return &src[begin..end];
 }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -11,7 +11,7 @@ use racer::util::txt_matches;
 
 fn find_start_of_function_body(src: &str) -> usize {
     // TODO: this should ignore anything inside parens so as to skip the arg list
-    return src.find_str("{").unwrap();
+    src.find_str("{").unwrap()
 }
 
 // Removes the body of the statement (anything in the braces {...}), leaving just
@@ -20,16 +20,16 @@ fn find_start_of_function_body(src: &str) -> usize {
 pub fn generate_skeleton_for_parsing(src: &str) -> String {
     let mut s = String::new();
     let n = src.find_str("{").unwrap();
-    s.push_str(src.slice_to(n+1));
+    s.push_str(&src[..n+1]);
     s.push_str("};");
-    return s;
+    s
 }
 
 pub fn first_param_is_self(blob: &str) -> bool {
     return blob.find_str("(").map_or(false, |start| {
         let end = scopes::find_closing_paren(blob, start+1);
-        debug!("searching fn args: |{}| {}",blob.slice(start+1,end), txt_matches(ExactMatch, "self", blob.slice(start+1,end)));
-        return txt_matches(ExactMatch, "self", blob.slice(start+1,end));
+        debug!("searching fn args: |{}| {}",&blob[(start+1)..end], txt_matches(ExactMatch, "self", &blob[(start+1)..end]));
+        return txt_matches(ExactMatch, "self", &blob[(start+1)..end]);
     });
 }
 
@@ -37,16 +37,16 @@ pub fn first_param_is_self(blob: &str) -> bool {
 fn generates_skeleton_for_mod() {
     let src = "mod foo { blah };";
     let out = generate_skeleton_for_parsing(src);
-    assert_eq!("mod foo {};", out.as_slice());
+    assert_eq!("mod foo {};", &out[]);
 }
 
 fn get_type_of_self_arg(m: &Match, msrc: &str) -> Option<racer::Ty> {
     debug!("get_type_of_self_arg {:?}", m);
     return scopes::find_impl_start(msrc, m.point, 0).and_then(|start| {
-        let decl = generate_skeleton_for_parsing(msrc.slice_from(start));
+        let decl = generate_skeleton_for_parsing(&msrc[start..]);
         debug!("get_type_of_self_arg impl skeleton |{}|", decl);
         
-        if decl.as_slice().starts_with("impl") {
+        if (&decl[]).starts_with("impl") {
             let implres = ast::parse_impl(decl);
             debug!("get_type_of_self_arg implres |{:?}|", implres);
             return resolve_path_with_str(&implres.name_path.expect("failed parsing impl name"), 
@@ -60,7 +60,7 @@ fn get_type_of_self_arg(m: &Match, msrc: &str) -> Option<racer::Ty> {
                            point: start,
                            local: m.local,
                            mtype: racer::MatchType::Trait,
-                           contextstr: racer::matchers::first_line(msrc.slice_from(start)),
+                           contextstr: racer::matchers::first_line(&msrc[start..]),
                            generic_args: Vec::new(), generic_types: Vec::new()
                 }))
             });
@@ -70,19 +70,19 @@ fn get_type_of_self_arg(m: &Match, msrc: &str) -> Option<racer::Ty> {
 
 fn get_type_of_fnarg(m: &Match, msrc: &str) -> Option<racer::Ty> {
     
-    if m.matchstr.as_slice() == "self" {
+    if &m.matchstr[] == "self" {
         return get_type_of_self_arg(m, msrc);
     }
 
     let stmtstart = scopes::find_stmt_start(msrc, m.point).unwrap();
-    let block = msrc.slice_from(stmtstart);
+    let block = &msrc[stmtstart..];
     if let Some((start,end)) = codeiter::iter_stmts(block).next() {
-        let blob = msrc.slice(stmtstart+start, stmtstart+end);
+        let blob = &msrc[(stmtstart+start)..(stmtstart+end)];
         // wrap in "impl blah { }" so that methods get parsed correctly too
         let mut s = String::new();
         s.push_str("impl blah {");
         let impl_header_len = s.len();
-        s.push_str(blob.slice_to(find_start_of_function_body(blob)+1));
+        s.push_str(&blob[..(find_start_of_function_body(blob)+1)]);
         s.push_str("}}");
         let argpos = m.point - (stmtstart+start) + impl_header_len;
         return ast::parse_fn_arg_type(s, argpos, racer::Scope::from_match(m));
@@ -94,9 +94,9 @@ fn get_type_of_let_expr(m: &Match, msrc: &str) -> Option<racer::Ty> {
     // ASSUMPTION: this is being called on a let decl
     let point = scopes::find_stmt_start(msrc, m.point).unwrap();
 
-    let src = msrc.slice_from(point);
+    let src = &msrc[point..];
     if let Some((start,end)) = codeiter::iter_stmts(src).next() { 
-        let blob = src.slice(start,end);
+        let blob = &src[start..end];
         debug!("get_type_of_let_expr calling parse_let |{}|",blob);
 
         let pos = m.point - point - start;
@@ -110,13 +110,13 @@ fn get_type_of_let_expr(m: &Match, msrc: &str) -> Option<racer::Ty> {
 fn get_type_of_if_let_expr(m: &Match, msrc: &str) -> Option<racer::Ty> {
     // ASSUMPTION: this is being called on an if let decl
     let stmtstart = scopes::find_stmt_start(msrc, m.point).unwrap();
-    let stmt = msrc.slice_from(stmtstart);
+    let stmt = &msrc[stmtstart..];
     let point = stmt.find_str("if let").unwrap();
-    let src = stmt.slice_from(point);
+    let src = &stmt[point..];
     let src = generate_skeleton_for_parsing(src);
 
     if let Some((start, end)) = codeiter::iter_stmts(&*src).next() {
-        let blob = src.slice(start,end);
+        let blob = &src[start..end];
         debug!("get_type_of_if_let_expr calling parse_if_let |{}|",blob);
 
         let pos = m.point - stmtstart - point - start;
@@ -134,13 +134,13 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match) -> Option<rac
     let src = racer::load_file(&structmatch.filepath);
 
     let opoint = scopes::find_stmt_start(&*src, structmatch.point);
-    let structsrc = scopes::end_of_next_scope(src.slice_from(opoint.unwrap()));
+    let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
 
     let fields = ast::parse_struct_fields(String::from_str(structsrc), 
                                           racer::Scope::from_match(structmatch));
     for (field, _, ty) in fields.into_iter() {
 
-        if fieldname == field.as_slice() {
+        if fieldname == &field[] {
             return ty;
         }
     }
@@ -152,14 +152,14 @@ pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match) -> Option<
 
     let structsrc = if let racer::MatchType::EnumVariant = structmatch.mtype {
         // decorate the enum variant src to make it look like a tuple struct
-        let to = src.slice_from(structmatch.point).find_str("(")
+        let to = (&src[structmatch.point..]).find_str("(")
             .map(|n| scopes::find_closing_paren(&*src, structmatch.point + n+1))
             .unwrap();
-        "struct ".to_string() + src.slice(structmatch.point, to+1) + ";"
+        "struct ".to_string() + &src[structmatch.point..(to+1)] + ";"
     } else {
         assert!(structmatch.mtype == racer::MatchType::Struct);
         let opoint = scopes::find_stmt_start(&*src, structmatch.point);
-        get_first_stmt(src.slice_from(opoint.unwrap())).to_string()
+        get_first_stmt(&src[opoint.unwrap()..]).to_string()
     };
 
     debug!("get_tuplestruct_field_type structsrc=|{}|",structsrc);
@@ -178,7 +178,7 @@ pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match) -> Option<
 
 pub fn get_first_stmt(src: &str) -> &str {
     match codeiter::iter_stmts(src).next() {
-        Some((from, to)) => src.slice(from,to),
+        Some((from, to)) => &src[from..to],
         None => src
     }    
 }
@@ -208,18 +208,18 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str) -> Option<racer::Ty> {
     // match stmt may be incomplete (half written) in the real code
 
     // skip to end of match arm pattern so we can search backwards
-    let arm = otry!(msrc.slice_from(m.point).find_str("=>")) + m.point;
+    let arm = otry!((&msrc[m.point..]).find_str("=>")) + m.point;
     let scopestart = scopes::scope_start(msrc, arm);
 
     let stmtstart = otry!(scopes::find_stmt_start(msrc, scopestart-1));
     debug!("PHIL preblock is {} {}", stmtstart, scopestart);
-    let preblock = msrc.slice(stmtstart, scopestart);
+    let preblock = &msrc[stmtstart..scopestart];
     let matchstart = otry!(util::find_last_str("match ", preblock)) + stmtstart;
 
     let lhs_start = scopes::get_start_of_pattern(msrc, arm);
-    let lhs = msrc.slice(lhs_start, arm);
+    let lhs = &msrc[lhs_start..arm];
     // construct faux match statement and recreate point
-    let mut fauxmatchstmt = msrc.slice(matchstart, scopestart).to_string();
+    let mut fauxmatchstmt = (&msrc[matchstart..scopestart]).to_string();
     let faux_prefix_size = fauxmatchstmt.len();
     fauxmatchstmt = fauxmatchstmt + lhs + " => () };";
     let faux_point = faux_prefix_size + (m.point - lhs_start);
@@ -238,11 +238,11 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str) -> Option<racer::Ty> {
 pub fn get_return_type_of_function(fnmatch: &Match) -> Option<racer::Ty> {
     let src = racer::load_file(&fnmatch.filepath);
     let point = scopes::find_stmt_start(&*src, fnmatch.point).unwrap();
-    return src.slice_from(point).find_str("{").and_then(|n|{
+    return (&src[point..]).find_str("{").and_then(|n|{
         // wrap in "impl blah { }" so that methods get parsed correctly too
         let mut decl = String::new();
         decl.push_str("impl blah {");
-        decl.push_str(src.slice(point, point+n+1));
+        decl.push_str(&src[point..(point+n+1)]);
         decl.push_str("}}");
         debug!("get_return_type_of_function: passing in |{}|",decl);
         return ast::parse_fn_output(decl, racer::Scope::from_match(fnmatch));

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -83,7 +83,7 @@ pub fn get_backtrace() -> String {
 }
 
 pub fn is_double_dot(msrc: &str, i: usize) -> bool {
-    (i > 1) && msrc.slice(i-1, i+1) == ".."
+    (i > 1) && &msrc[i-1..i+1] == ".."
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn txt_matches_matches_stuff() {
 
 
 pub fn expand_ident(s : &str, pos : usize) -> (usize,usize) {
-    let sb = s.slice_to(pos);
+    let sb = &s[..pos];
     let mut start = pos;
 
     // backtrack to find start of word
@@ -113,7 +113,7 @@ pub fn expand_ident(s : &str, pos : usize) -> (usize,usize) {
 
 pub fn find_ident_end(s : &str, pos : usize) -> usize {
     // find end of word
-    let sa = s.slice_from(pos);
+    let sa = &s[pos..];
     let mut end = pos;
     for (i, c) in sa.char_indices() {
         if !is_ident_char(c) {
@@ -127,7 +127,7 @@ pub fn find_ident_end(s : &str, pos : usize) -> usize {
 pub fn to_refs<'a>(v: &'a Vec<String>) -> Vec<&'a str> {
     let mut out = Vec::new();
     for item in v.iter() {
-        out.push(item.as_slice()); 
+        out.push(&item[]); 
     }
     return out;
 }
@@ -136,7 +136,7 @@ pub fn find_last_str(needle: &str, mut haystack: &str) -> Option<usize> {
     let mut res = None;
     while let Some(n) = haystack.find_str(needle) {
         res = Some(n);
-        haystack = haystack.slice_from(n+1);
+        haystack = &haystack[n+1..];
     }
     return res;
 }


### PR DESCRIPTION
Hi,

Slice functions such as 'as_slice', 'slice_from', 'slice_to' and 'slice' are supposed to be deprecated in favor of range patterns [], [x..], [..x], [x..y] respectively.
This pull requests proposes all the necessary changes.
With the last rust, it reduces the number of warnings.

4 tests fails, as they do in master as well.

Just let me know if it helps or if I must make some more changes !

Johann