### PR TITLE
Review codecleaner: iterators/chars instead of while/bytes

### DIFF
--- a/src/racer/bench.rs
+++ b/src/racer/bench.rs
@@ -1,0 +1,23 @@
+extern crate test;
+
+use std::io::fs::PathExtensions;
+use std::os::getenv;
+use racer::codecleaner::code_chunks;
+use std::io::File;
+use self::test::Bencher;
+
+#[bench]
+fn bench_code_chunks(b: &mut Bencher) {
+    
+    let mut src_path = Path::new(&getenv("RUST_SRC_PATH").unwrap()[]);
+    src_path.push("libcollections");
+    src_path.push("bit.rs");
+    
+    let src = &File::open(&src_path).read_to_string().unwrap()[];
+    
+    b.iter(|| {
+        let chunks = code_chunks(src).collect::<Vec<_>>();
+    });
+}
+
+

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -13,6 +13,7 @@ pub mod util;
 pub mod matchers;
 
 #[cfg(test)] pub mod test;
+#[cfg(test)] pub mod bench;
 
 #[derive(Show,Clone,PartialEq)]
 pub enum MatchType {


### PR DESCRIPTION
Hi,

I did a review of codecleaner.

The main changes are :
- change byte to chars in order to improve readability (i am not sure if performance is better or not, but i think this might be marginal)
- change while loop to iterators. It feels more 'rust' this way. I think perf will be better (not that it mattered that much ... but why not !)
- change ifs to match: again feels more 'rust' and improves readability (to me at least)

I just tried to replicate the logic without having the very global picture. I trusted the tests to check if all is OK. 

Let me know if it helps or not and if i can continue on the other files.