### PR TITLE
Add bench module

### DIFF
--- a/src/racer/bench.rs
+++ b/src/racer/bench.rs
@@ -1,0 +1,23 @@
+extern crate test;
+
+use std::io::fs::PathExtensions;
+use std::os::getenv;
+use racer::codecleaner::code_chunks;
+use std::io::File;
+use self::test::Bencher;
+
+#[bench]
+fn bench_code_chunks(b: &mut Bencher) {
+    
+    let mut src_path = Path::new(&getenv("RUST_SRC_PATH").unwrap()[]);
+    src_path.push("libcollections");
+    src_path.push("bit.rs");
+    
+    let src = &File::open(&src_path).read_to_string().unwrap()[];
+    
+    b.iter(|| {
+        let chunks = code_chunks(src).collect::<Vec<_>>();
+    });
+}
+
+

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -13,6 +13,7 @@ pub mod util;
 pub mod matchers;
 
 #[cfg(test)] pub mod test;
+#[cfg(test)] pub mod bench;
 
 #[derive(Show,Clone,PartialEq)]
 pub enum MatchType {


### PR DESCRIPTION
This adds a new bench.rs file, similar to test.rs.
It contains only one bench now but it is supposed to be extended.
Like test, this file is compiled only when testing and won't affect release build.