### PR TITLE
Review code iter

### DIFF
--- a/src/racer/bench.rs
+++ b/src/racer/bench.rs
@@ -1,0 +1,23 @@
+extern crate test;
+
+use std::io::fs::PathExtensions;
+use std::os::getenv;
+use racer::codecleaner::code_chunks;
+use std::io::File;
+use self::test::Bencher;
+
+#[bench]
+fn bench_code_chunks(b: &mut Bencher) {
+    
+    let mut src_path = Path::new(&getenv("RUST_SRC_PATH").unwrap()[]);
+    src_path.push("libcollections");
+    src_path.push("bit.rs");
+    
+    let src = &File::open(&src_path).read_to_string().unwrap()[];
+    
+    b.iter(|| {
+        let chunks = code_chunks(src).collect::<Vec<_>>();
+    });
+}
+
+

--- a/src/racer/bench.rs
+++ b/src/racer/bench.rs
@@ -2,22 +2,35 @@ extern crate test;
 
 use std::io::fs::PathExtensions;
 use std::os::getenv;
-use racer::codecleaner::code_chunks;
 use std::io::File;
 use self::test::Bencher;
+use racer::codecleaner::code_chunks;
+use racer::codeiter::iter_stmts;
+
+fn get_rust_file_str(path: &[&str]) -> String {
+
+    let mut src_path = match getenv("RUST_SRC_PATH") {
+        Some(env) => { Path::new(&env[]) },
+        None => panic!("Cannot find $RUST_SRC_PATH")
+    };
+    for &s in path.iter() { src_path.push(s); }
+
+    File::open(&src_path).read_to_string().unwrap()
+}
 
 #[bench]
 fn bench_code_chunks(b: &mut Bencher) {
-    
-    let mut src_path = Path::new(&getenv("RUST_SRC_PATH").unwrap()[]);
-    src_path.push("libcollections");
-    src_path.push("bit.rs");
-    
-    let src = &File::open(&src_path).read_to_string().unwrap()[];
-    
+    let src = &get_rust_file_str(&["libcollections", "bit.rs"])[];
     b.iter(|| {
         let chunks = code_chunks(src).collect::<Vec<_>>();
     });
 }
 
+#[bench]
+fn bench_iter_stmts(b: &mut Bencher) {
+    let src = &get_rust_file_str(&["libcollections", "bit.rs"])[];
+    b.iter(|| {
+        let chunks = iter_stmts(src).collect::<Vec<_>>();
+    });
+}
 

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -22,7 +22,7 @@ impl<'a> Iterator for StmtIndicesIter<'a> {
 
         let src_bytes = self.src.as_bytes();
         let mut enddelim = b';';
-        let mut bracelevel = 02;
+        let mut bracelevel = 0u16;
         let mut parenlevel = 0i32;
         let mut start = self.pos;
 

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -11,12 +11,7 @@ pub struct StmtIndicesIter<'a> {
     src: &'a str,
     it: CodeIndicesIter<'a>,
     pos: usize,
-    start: usize,
-    end: usize,
-    bracelevel: i32,
-    parenlevel: i32,
-    is_macro: bool,
-    enddelim: u8
+    end: usize
 }
 
 impl<'a> Iterator for StmtIndicesIter<'a> {
@@ -24,130 +19,91 @@ impl<'a> Iterator for StmtIndicesIter<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<(usize, usize)> {
-        let semicolon: u8 = ";".as_bytes()[0];
-        let hash: u8 = "#".as_bytes()[0];
-        let openbrace: u8 = "{".as_bytes()[0];
-        let closebrace: u8 = "}".as_bytes()[0];
-        let openparen: u8 = "(".as_bytes()[0];
-        let closeparen: u8 = ")".as_bytes()[0];
-        let closesqbrace: u8 = "]".as_bytes()[0];
-        let bang: u8 = "!".as_bytes()[0];
-        let whitespace = " \t\r\n".as_bytes();
-
-        let __u: u8 = "u".as_bytes()[0];
-        let __s: u8 = "s".as_bytes()[0];
-        let __e: u8 = "e".as_bytes()[0];
-
 
         let src_bytes = self.src.as_bytes();
+        let mut enddelim = b';';
+        let mut bracelevel = 02;
+        let mut parenlevel = 0i32;
+        let mut start = self.pos;
 
+        // loop on all code_chuncks until we find a relevant open/close pattern
         loop {
 
             // do we need the next chunk?
-            if self.end <= self.pos {
+            if self.end == self.pos {
                 // get the next chunk of code
                 match self.it.next() {
-                    Some((start, end)) => {
-                        self.end = end;
-                        if self.start == self.pos {
-                            self.start = start;
-                        }
-                        self.pos = start;
+                    Some((ch_start, ch_end)) => {
+                        self.end = ch_end;
+                        if start == self.pos { start = ch_start; }
+                        self.pos = ch_start;
                     }
                     None => {
                         // no more chunks. finished
-                        if self.start < self.end {
-                            let start = self.start;
-                            self.start = self.end;
-                            return Some((start, self.end));
-                        } else {
-                            return None
-                        }
-
+                        return if start < self.end { Some((start, self.end)) }
+                        else { None }
                     }
                 }
             }
-
-            // if this is a new stmt block, skip the whitespace
-            if self.pos == self.start {
-                while self.pos < self.end {
-                    if !whitespace.contains(&src_bytes[self.pos]) {
-                        break;
-                    } else {
-                        self.pos += 1;
-                    }
-                }
-                self.start = self.pos;
-            }
-
             
-            // if the statement starts with 'macro_rules!' then we're in a macro
-            // We need to know this because a closeparen can terminate a macro
-            if (self.end - self.pos) > 12 && 
-                &self.src[self.pos..self.pos+12] == "macro_rules!" {
-                self.is_macro = true;
+            if start == self.pos {
+                // if this is a new stmt block, skip the whitespace
+                for &b in src_bytes[self.pos..self.end].iter() {
+                    match b {
+                        b' ' | b'\r' | b'\n' | b'\t' => { self.pos += 1; },
+                        _ => { break; }
+                    }
+                }
+                start = self.pos;
+
+                // test attribute   #[foo = bar]
+                if self.pos<self.end && src_bytes[self.pos] == b'#' { 
+                    enddelim = b']' 
+                };
             }
 
             // iterate through the chunk, looking for stmt end
-            while self.pos < self.end {
-                if src_bytes[self.pos] == openparen {
-
-                    // macros can be terminated by closeparen if opened by one
-                    if self.is_macro &&
-                        self.bracelevel == 0 && 
-                        self.parenlevel == 0 {
-                        self.enddelim = closeparen;
-                    }
-                    
-                    // also macro invocations can too
-                    if self.pos > 0 && src_bytes[self.pos-1] == bang &&
-                        self.bracelevel == 0 && 
-                        self.parenlevel == 0 {
-                        self.enddelim = closeparen;
-                    }
-
-                    self.parenlevel += 1;
-
-                } else if src_bytes[self.pos] == closeparen {
-                    self.parenlevel -= 1;
-
-                } else if src_bytes[self.pos] == openbrace {
-                    // if we are top level and stmt is not a 'use' then 
-                    // closebrace finishes the stmt
-                    if self.bracelevel == 0 && 
-                        self.parenlevel == 0 &&
-                       !(is_a_use_stmt(self.src, self.start, self.pos)) {
-                           self.enddelim = closebrace;
-                    }
-                    self.bracelevel += 1;
-
-                } else if src_bytes[self.pos] == closebrace {
-                    self.bracelevel -= 1;
-                    // have we reached the end of the scope?
-                    if self.bracelevel < 0 {
-                        return None;
-                    }
-                }
-
-                // attribute   #[foo = bar]
-                if self.bracelevel == 0 && self.start == self.pos && 
-                    src_bytes[self.pos] == hash {
-                    self.enddelim = closesqbrace;
-                }
-
-                if self.bracelevel == 0 && self.parenlevel == 0 && 
-                   src_bytes[self.pos] == self.enddelim {
-                    let start = self.start;
-                    self.start = self.pos+1;
-                    self.pos = self.pos+1;
-                    self.enddelim = semicolon;
-                    self.is_macro = false;
-                    return Some((start, self.pos));
-                }
+            for &b in src_bytes[self.pos..self.end].iter() {
 
                 self.pos += 1;
+
+                match b {
+                    b'(' => { parenlevel += 1; },
+                    b')' => { parenlevel -= 1; },
+                    b'{' => {
+                        // if we are top level and stmt is not a 'use' then 
+                        // closebrace finishes the stmt
+                        if bracelevel == 0 && parenlevel == 0 
+                            && !(is_a_use_stmt(self.src, start, self.pos)) {
+                            enddelim = b'}';
+                        }
+                        bracelevel += 1;
+                    },
+                    b'}' => {
+                        // have we reached the end of the scope?
+                        if bracelevel == 0 { return None; }
+                        bracelevel -= 1;
+                    },
+                    b'!' => {
+                        // macro if followed by at least one space or (
+                        // FIXME: test with boolean 'not' expression
+                        if parenlevel == 0 && bracelevel == 0
+                            && self.pos < self.end && (self.pos-start)>1 {
+                            match src_bytes[self.pos] {
+                                b' ' | b'\r' | b'\n' | b'\t' | b'('  => { 
+                                    enddelim = b')';
+                                },
+                                _ => {}
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+
+                if enddelim == b && bracelevel == 0 && parenlevel == 0 { 
+                    return Some((start, self.pos));
+                }
             }
-            
         }
     }
 }
@@ -155,17 +111,14 @@ impl<'a> Iterator for StmtIndicesIter<'a> {
 fn is_a_use_stmt(src: &str, start: usize, pos: usize) -> bool {
     let src_bytes = src.as_bytes();
     let whitespace = " {\t\r\n".as_bytes();
-    (pos > 3 && &src_bytes[start..start+3] == "use".as_bytes() && 
+    (pos > 3 && &src_bytes[start..start+3] == b"use" && 
      whitespace.contains(&src_bytes[start+3])) || 
-        (pos > 7 && &src_bytes[start..(start+7)] == "pub use".as_bytes() &&
-                      whitespace.contains(&src_bytes[start+7]))
+    (pos > 7 && &src_bytes[start..(start+7)] == b"pub use" &&
+     whitespace.contains(&src_bytes[start+7]))
 }
 
 pub fn iter_stmts<'a>(src: &'a str) -> StmtIndicesIter<'a> {
-    let semicolon: u8 = ";".as_bytes()[0];
-    StmtIndicesIter{src: src, it: code_chunks(src), 
-                    pos: 0, start: 0, end: 0, bracelevel: 0, 
-                    parenlevel: 0, enddelim: semicolon, is_macro: false}
+    StmtIndicesIter{src: src, it: code_chunks(src), pos: 0, end: 0}
 }
 
 

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -13,6 +13,7 @@ pub mod util;
 pub mod matchers;
 
 #[cfg(test)] pub mod test;
+#[cfg(test)] pub mod bench;
 
 #[derive(Show,Clone,PartialEq)]
 pub enum MatchType {


### PR DESCRIPTION
Another review: codeiter
It mostly improves readability (to me at least), most of the logic hasn't changed, except for macros declaration.
- iterators instead of while
- matches instead of ifs
- remove several StmtIndicesIter members

I also added a bench to compare. On my system there is a mere 4% improvement, nothing significant but at least it is not worse.

I think a 'merge' between codeiter and codecleaner might be possible to avoid reading the src twice, i don't know yet all the impacts so i'll see for it later.

Again, let me know.