### PR TITLE
The 'io' module was renamed to 'old_io'

### DIFF
--- a/src/racer/bench.rs
+++ b/src/racer/bench.rs
@@ -1,8 +1,8 @@
 extern crate test;
 
-use std::io::fs::PathExtensions;
+use std::old_io::fs::PathExtensions;
 use std::os::getenv;
-use std::io::File;
+use std::old_io::File;
 use self::test::Bencher;
 use racer::codecleaner::code_chunks;
 use racer::codeiter::iter_stmts;

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -1,5 +1,5 @@
-use std::io::File;
-use std::io::BufferedReader;
+use std::old_io::File;
+use std::old_io::BufferedReader;
 use std::{str,vec,fmt,path};
 
 pub mod scopes;
@@ -234,7 +234,7 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize) -> vec::
         CompletionType::CompletePath => {
             let mut v = expr.split_str("::").collect::<Vec<_>>();
             let mut global = false;
-            if v[0] == "" {      // i.e. starts with '::' e.g. ::std::io::blah
+            if v[0] == "" {      // i.e. starts with '::' e.g. ::std::old_io::blah
                 v.remove(0);
                 global = true;
             }
@@ -285,7 +285,7 @@ pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize) -> Option<
         CompletionType::CompletePath => {
             let mut v = expr.split_str("::").collect::<Vec<_>>();
             let mut global = false;
-            if v[0] == "" {      // i.e. starts with '::' e.g. ::std::io::blah
+            if v[0] == "" {      // i.e. starts with '::' e.g. ::std::old_io::blah
                 v.remove(0);
                 global = true;
             }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -17,7 +17,7 @@ use racer::ast;
 use racer::util;
 use racer::util::{symbol_matches, txt_matches, find_ident_end};
 use racer::scopes;
-use std::io::{File};
+use std::old_io::{File};
 use std::{vec};
 use std::iter::Iterator;
 use std;
@@ -315,7 +315,7 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
     v.push(currentdir.as_str().unwrap());
     debug!("do_file_search v is {:?}",v);
     for srcpath in v.into_iter() {
-        match std::io::fs::readdir(&Path::new(srcpath)) {
+        match std::old_io::fs::readdir(&Path::new(srcpath)) {
             Ok(v) => {
                 for fpath in v.iter() {
                     //debug!("fpath {}",fpath.as_str());

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -1,5 +1,5 @@
-use std::io::File;
-use std::io::BufferedReader;
+use std::old_io::File;
+use std::old_io::BufferedReader;
 
 use racer;
 use racer::util;

--- a/src/racer/test.rs
+++ b/src/racer/test.rs
@@ -1,6 +1,6 @@
 use racer::complete_from_file;
 use racer::find_definition;
-use std::io::File;
+use std::old_io::File;
 use std::thread;
 use racer::scopes;
 
@@ -20,7 +20,7 @@ fn write_file(tmppath:&Path, s : &str) {
 }
 
 fn remove_file(tmppath:&Path) {
-    ::std::io::fs::unlink(tmppath).unwrap();
+    ::std::old_io::fs::unlink(tmppath).unwrap();
 }
 
 #[test]
@@ -352,7 +352,7 @@ fn follows_self_use() {
     ";
     let basedir = tmpname();
     let moddir = basedir.join("mymod");
-    ::std::io::fs::mkdir_recursive(&moddir, ::std::io::USER_RWX).unwrap();
+    ::std::old_io::fs::mkdir_recursive(&moddir, ::std::old_io::USER_RWX).unwrap();
 
     write_file(&moddir.join("mod.rs"), modsrc);
     write_file(&moddir.join("src2.rs"), src2);
@@ -360,7 +360,7 @@ fn follows_self_use() {
     write_file(&srcpath, src);
     let pos = scopes::coords_to_point(src, 6, 10);
     let got = find_definition(src, &srcpath, pos).unwrap();
-    ::std::io::fs::rmdir_recursive(&basedir).unwrap();
+    ::std::old_io::fs::rmdir_recursive(&basedir).unwrap();
     assert_eq!(got.matchstr,"myfn".to_string());
     assert_eq!(moddir.join("src2.rs").display().to_string(), 
                got.filepath.display().to_string());
@@ -385,12 +385,12 @@ fn finds_nested_submodule_file() {
     let basedir = tmpname();
     let srcpath = basedir.join("root.rs");
     let sub2dir = basedir.join("sub1").join("sub2");
-    ::std::io::fs::mkdir_recursive(&sub2dir, ::std::io::USER_RWX).unwrap();
+    ::std::old_io::fs::mkdir_recursive(&sub2dir, ::std::old_io::USER_RWX).unwrap();
     write_file(&srcpath, rootsrc);
     write_file(&sub2dir.join("sub3.rs"), sub3src);
     let pos = scopes::coords_to_point(rootsrc, 7, 23);
     let got = find_definition(rootsrc, &srcpath, pos).unwrap();
-    ::std::io::fs::rmdir_recursive(&basedir).unwrap();
+    ::std::old_io::fs::rmdir_recursive(&basedir).unwrap();
     assert_eq!(got.matchstr,"myfn".to_string());
     assert_eq!(sub2dir.join("sub3.rs").display().to_string(), 
                got.filepath.display().to_string());
@@ -415,7 +415,7 @@ fn follows_use_to_impl() {
     }
     ";
     let basedir = tmpname();
-    ::std::io::fs::mkdir_recursive(&basedir, ::std::io::USER_RWX).unwrap();
+    ::std::old_io::fs::mkdir_recursive(&basedir, ::std::old_io::USER_RWX).unwrap();
 
     let modpath = basedir.join("mymod.rs");
     write_file(&modpath, modsrc);
@@ -424,7 +424,7 @@ fn follows_use_to_impl() {
     let pos = scopes::coords_to_point(src, 5, 14);
     let got = find_definition(src, &srcpath, pos).unwrap();
 
-    ::std::io::fs::rmdir_recursive(&basedir).unwrap();
+    ::std::old_io::fs::rmdir_recursive(&basedir).unwrap();
     assert_eq!(got.matchstr,"new".to_string());
     assert_eq!(90, got.point);
     assert_eq!(modpath.display().to_string(), 

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -1,5 +1,5 @@
 // Small functions of utility
-use std::io::{File, BufferedReader};
+use std::old_io::{File, BufferedReader};
 use racer::{SearchType};
 use racer::SearchType::{ExactMatch, StartsWith};
 use std;
@@ -75,7 +75,7 @@ pub fn symbol_matches(stype: SearchType, searchstr: &str, candidate: &str) -> bo
 }
 
 pub fn get_backtrace() -> String {
-    let mut m = std::io::MemWriter::new();
+    let mut m = std::old_io::MemWriter::new();
     let s = std::rt::backtrace::write(&mut m)
         .ok().map_or("NO backtrace".to_string(), 
                      |_| String::from_utf8_lossy(m.get_ref()).to_string());


### PR DESCRIPTION
This makes racer compile again as of rustc 1.0.0-dev (d77f6d536 2015-01-27 11:07:26 +0000)

See rust-lang/rust#21543 for details