### PR TITLE
Making Racer compile with newest Rust by removing unchecked debug calls

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -753,7 +753,7 @@ fn search_local_scopes(pathseg: &racer::PathSegment, filepath: &Path,
 pub fn search_prelude_file(pathseg: &racer::PathSegment, search_type: SearchType, 
                            namespace: Namespace) -> vec::IntoIter<Match> {
     debug!("search_prelude file {:?} {:?} {:?}", pathseg, search_type, namespace);
-    debug!("PHIL searching prelude file, backtrace: {}",util::get_backtrace());
+//    debug!("PHIL searching prelude file, backtrace: {}",util::get_backtrace());
 
     let mut out : Vec<Match> = Vec::new();
 

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -74,13 +74,13 @@ pub fn symbol_matches(stype: SearchType, searchstr: &str, candidate: &str) -> bo
     }
 }
 
-pub fn get_backtrace() -> String {
-    let mut m = std::old_io::MemWriter::new();
-    let s = std::rt::backtrace::write(&mut m)
-        .ok().map_or("NO backtrace".to_string(), 
-                     |_| String::from_utf8_lossy(m.get_ref()).to_string());
-    return s;
-}
+// pub fn get_backtrace() -> String {
+//     let mut m = std::old_io::MemWriter::new();
+//     let s = std::rt::backtrace::write(&mut m)
+//         .ok().map_or("NO backtrace".to_string(), 
+//                      |_| String::from_utf8_lossy(m.get_ref()).to_string());
+//     return s;
+// }
 
 pub fn is_double_dot(msrc: &str, i: usize) -> bool {
     (i > 1) && &msrc[i-1..i+1] == ".."


### PR DESCRIPTION
As suggested in issue #126, backtrace is just breaking build now.