### PR TITLE
implement getting signature of function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,12 +120,40 @@ fn find_definition() {
 }
 
 #[cfg(not(test))]
+fn signatureof() {
+        let args = std::os::args();
+    if args.len() < 5 {
+        println!("Provide more arguments!");
+        print_usage();
+        std::os::set_exit_status(1);
+        return;
+    }
+    let linenum = args[2].parse::<usize>().unwrap();
+    let charnum = args[3].parse::<usize>().unwrap();
+    let fname = &args[4][];
+    let fpath = Path::new(fname);
+    let src = racer::load_file(&fpath);
+    let pos = scopes::coords_to_point(&*src, linenum, charnum);
+
+    let info = racer::signatureof(&*src, &fpath, pos);
+
+    if let Some(ret) = info.output {
+        println!("RETURNS {}", ret);
+    }
+
+    for arg in info.args.iter() {
+        println!("ARG {}", arg);
+    }
+}
+
+#[cfg(not(test))]
 fn print_usage() {
     let program = std::os::args()[0].clone();
     println!("usage: {} complete linenum charnum fname", program);
     println!("or:    {} find-definition linenum charnum fname", program);
     println!("or:    {} complete fullyqualifiedname   (e.g. std::io::)",program);
     println!("or:    {} prefix linenum charnum fname",program);
+    println!("or:    {} signatureof linenum charnum fname", program);
 }
 
 
@@ -150,6 +178,7 @@ fn main() {
         "prefix" => prefix(),
         "complete" => complete(),
         "find-definition" => find_definition(),
+        "signatureof" => signatureof(),
         "help" => print_usage(),
         _ => {
             println!("Sorry, I didn't understand command {}", command );

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,8 @@ fn signatureof() {
 
     let info = racer::signatureof(&*src, &fpath, pos);
 
+    println!("NAME {}", info.name);
+
     if let Some(ret) = info.output {
         println!("RETURNS {}", ret);
     }

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -270,14 +270,11 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize) -> vec::
 
 
 pub fn signatureof(src: &str, filepath: &path::Path, pos: usize) -> ast::MethDeclInfo {
-    println!("starting");
-
     //this should work as long positions is somewhere in the name of the function
     let start_index = src[..pos+1].rfind(' ').unwrap();
     let end_index = src[pos..].find('{').unwrap()+pos;
     let mtch = format!("fn {}",src[start_index..end_index].trim());
-
-    println!("{}",mtch);
+    
     return ast::MethDeclInfo::from_source_str(mtch);
 }
 

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -269,6 +269,20 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize) -> vec::
 }
 
 
+pub fn signatureof(src: &str, filepath: &path::Path, pos: usize) -> ast::MethDeclInfo {
+    println!("starting");
+    if let Some(mtch) = find_definition_(src, filepath, pos) {
+        println!("found_match {}", mtch.contextstr);
+        if mtch.mtype == MatchType::Function {
+            let matches: &[_] = &['\n','\r','{',' '];
+            let source = mtch.contextstr.as_slice().trim_right_matches(matches).to_string();
+            println!("source {}", source);
+            return ast::MethDeclInfo::from_source_str(source);
+        }
+    }
+    panic!("could not find match")
+}
+
 pub fn find_definition(src: &str, filepath: &path::Path, pos: usize) -> Option<Match> {
     return find_definition_(src, filepath, pos);
 }

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -270,9 +270,11 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize) -> vec::
 
 
 pub fn signatureof(src: &str, filepath: &path::Path, pos: usize) -> ast::MethDeclInfo {
-    //this should work as long positions is somewhere in the name of the function
-    let start_index = src[..pos+1].rfind(' ').unwrap();
-    let end_index = src[pos..].find('{').unwrap()+pos;
+    
+    let def = find_definition(src, filepath, pos).expect("Could not find definition of this method.");
+
+    let start_index = src[..def.point+1].rfind(' ').expect("Could not find start of the method declaration");
+    let end_index = src[def.point..].find('{').expect("Could not find end of the method declaration")+def.point;
     let mtch = format!("fn {}",src[start_index..end_index].trim());
     
     return ast::MethDeclInfo::from_source_str(mtch);

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -271,16 +271,14 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize) -> vec::
 
 pub fn signatureof(src: &str, filepath: &path::Path, pos: usize) -> ast::MethDeclInfo {
     println!("starting");
-    if let Some(mtch) = find_definition_(src, filepath, pos) {
-        println!("found_match {}", mtch.contextstr);
-        if mtch.mtype == MatchType::Function {
-            let matches: &[_] = &['\n','\r','{',' '];
-            let source = mtch.contextstr.as_slice().trim_right_matches(matches).to_string();
-            println!("source {}", source);
-            return ast::MethDeclInfo::from_source_str(source);
-        }
-    }
-    panic!("could not find match")
+
+    //this should work as long positions is somewhere in the name of the function
+    let start_index = src[..pos+1].rfind(' ').unwrap();
+    let end_index = src[pos..].find('{').unwrap()+pos;
+    let mtch = format!("fn {}",src[start_index..end_index].trim());
+
+    println!("{}",mtch);
+    return ast::MethDeclInfo::from_source_str(mtch);
 }
 
 pub fn find_definition(src: &str, filepath: &path::Path, pos: usize) -> Option<Match> {

--- a/src/racer/test.rs
+++ b/src/racer/test.rs
@@ -1112,16 +1112,25 @@ fn add(a : i32, b : i32) -> i32{
 #[test]
 fn handles_signature_extraction() {
     let src="
-    fn add(a : i32, b : i32) -> i32{
+    fn main() {
+        let d = Foo{x:1};
+        add(1,2);
+        d.string_to_parser();
+        d.with_error_checking_parse(1);
     }
-    pub fn string_to_parser<'a>(&self, ps: &'a ParseSess, source_str: String) -> Parser<'a> {
-    }
-    fn with_error_checking_parse<F, T>(&self, s: String, f: F) -> T where F: Fn(&mut Parser) -> T {
+
+    fn add(a : i32, b : i32) -> i32 {a+b}
+
+    struct Foo {x : i32}
+
+    impl Foo {
+        pub fn string_to_parser(&self) {}
+        pub fn with_error_checking_parse<T>(&self, x : T) -> T {x}
     }
     ";
     let path = tmpname();
     write_file(&path, src);
-    let pos = scopes::coords_to_point(src, 2, 7);
+    let pos = scopes::coords_to_point(src, 4, 10);
     let info = signatureof(src, &path, pos);
 
     assert_eq!(info.name, "add".to_string());
@@ -1129,17 +1138,16 @@ fn handles_signature_extraction() {
     assert_eq!(info.args[0], "a: i32".to_string());
     assert_eq!(info.output, Some("i32".to_string()));
 
-    let pos = scopes::coords_to_point(src, 4, 10);
+    let pos = scopes::coords_to_point(src, 5, 13);
     let info = signatureof(src, &path, pos);
     assert_eq!(info.name, "string_to_parser".to_string());
-    assert_eq!(info.args.len(), 3);
-    assert_eq!(info.args[1], "ps: &'a ParseSess".to_string());
-    assert_eq!(info.output, Some("Parser<'a>".to_string()));
+    assert_eq!(info.args.len(), 1);
+    assert_eq!(info.args[0], "self".to_string());
 
-        let pos = scopes::coords_to_point(src, 6, 7);
+    let pos = scopes::coords_to_point(src, 6, 13);
     let info = signatureof(src, &path, pos);
     assert_eq!(info.name, "with_error_checking_parse".to_string());
-    assert_eq!(info.args.len(), 3);
+    assert_eq!(info.args.len(), 2);
     assert_eq!(info.args[0], "self".to_string());
     assert_eq!(info.output, Some("T".to_string()));
 


### PR DESCRIPTION
I'm trying to implement feature from issue #41.

This is not ready yet, I just wanted to ask something. I used find_definition_ to get declaration of the requested function, but in the complex case on the test, the contextstr is
"pub fn string_to_parser<'        'a ParseSess, source_str: String) -> Parser<'"
so few chars at the end are missing. 

Is this a bug of the find_definition_ function?