### PR TITLE
add snippets to method/function matches

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,25 @@ use racer::scopes;
 
 use racer::MatchType;
 
-use racer::method_info::MethodInfo;
-
 pub mod racer;
+
+#[cfg(not(test))]
+fn match_with_snippet_fn(m:Match) {
+    let (linenum, charnum) = scopes::point_to_coords_from_file(&m.filepath, m.point).unwrap();
+    if m.matchstr == "" {
+        panic!("MATCHSTR is empty - waddup?");
+    }
+
+    let snippet = racer::snippets::snippet_for_match(&m);
+    println!("MATCH {};{};{};{};{};{:?};{}", m.matchstr,
+                                    snippet,
+                                    linenum.to_string(),
+                                    charnum.to_string(),
+                                    m.filepath.as_str().unwrap(),
+                                    m.mtype,
+                                    m.contextstr,
+             );
+}
 
 #[cfg(not(test))]
 fn match_fn(m:Match) {
@@ -27,28 +43,17 @@ fn match_fn(m:Match) {
     if m.matchstr == "" {
         panic!("MATCHSTR is empty - waddup?");
     }
-
-    let mut snippet : String = "".to_string();
-    if m.mtype == MatchType::Function {
-        snippet.push_str(", ???");
-        let info = MethodInfo::from_source_str(m.contextstr.as_slice());
-        snippet.push_str(info.snippet().as_slice());
-    }
-
-
-
-    println!("MATCH {},{},{},{},{:?},{},???{}", m.matchstr,
+    println!("MATCH {},{},{},{},{:?},{}", m.matchstr,
                                     linenum.to_string(),
                                     charnum.to_string(),
                                     m.filepath.as_str().unwrap(),
                                     m.mtype,
-                                    m.contextstr,
-                                    snippet
+                                    m.contextstr
              );
 }
 
 #[cfg(not(test))]
-fn complete() {
+fn complete(match_found : &Fn(Match)) {
     let args = std::os::args();
     if args.len() < 3 {
         println!("Provide more arguments!");
@@ -75,7 +80,7 @@ fn complete() {
 
             let point = scopes::coords_to_point(&*src, linenum, charnum);
             for m in racer::complete_from_file(&*src, &fpath, point) {
-                match_fn(m);
+                match_found(m);
             }
         }
         Err(_) => {
@@ -86,10 +91,10 @@ fn complete() {
 
             for m in do_file_search(p[0], &Path::new(".")) {
                 if p.len() == 1 {
-                    match_fn(m);
+                    match_found(m);
                 } else {
                     for m in do_external_search(&p[1..], &m.filepath, m.point, racer::SearchType::StartsWith, racer::Namespace::BothNamespaces) {
-                        match_fn(m);
+                        match_found(m);
                     }
                 }
             }
@@ -143,6 +148,7 @@ fn print_usage() {
     println!("or:    {} find-definition linenum charnum fname", program);
     println!("or:    {} complete fullyqualifiedname   (e.g. std::io::)",program);
     println!("or:    {} prefix linenum charnum fname",program);
+    println!("or replace complete with complete-with-snippet for more detailed completions.");
 }
 
 
@@ -165,7 +171,8 @@ fn main() {
     let command = &args[1][];
     match command {
         "prefix" => prefix(),
-        "complete" => complete(),
+        "complete" => complete(&match_fn),
+        "complete-with-snippet" => complete(&match_with_snippet_fn),
         "find-definition" => find_definition(),
         "help" => print_usage(),
         _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,10 @@ use racer::nameres::{do_file_search, do_external_search};
 #[cfg(not(test))]
 use racer::scopes;
 
+use racer::MatchType;
+
+use racer::method_info::MethodInfo;
+
 pub mod racer;
 
 #[cfg(not(test))]
@@ -23,12 +27,23 @@ fn match_fn(m:Match) {
     if m.matchstr == "" {
         panic!("MATCHSTR is empty - waddup?");
     }
-    println!("MATCH {},{},{},{},{:?},{}", m.matchstr,
+
+    let mut snippet : String = "".to_string();
+    if m.mtype == MatchType::Function {
+        snippet.push_str(", ???");
+        let info = MethodInfo::from_source_str(m.contextstr.as_slice());
+        snippet.push_str(info.snippet().as_slice());
+    }
+
+
+
+    println!("MATCH {},{},{},{},{:?},{},???{}", m.matchstr,
                                     linenum.to_string(),
                                     charnum.to_string(),
                                     m.filepath.as_str().unwrap(),
                                     m.mtype,
-                                    m.contextstr
+                                    m.contextstr,
+                                    snippet
              );
 }
 

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -27,7 +27,7 @@ pub fn string_to_parser<'a>(ps: &'a ParseSess, source_str: String) -> Parser<'a>
                                source_str)
 }
 
-fn with_error_checking_parse<F, T>(s: String, f: F) -> T where F: Fn(&mut Parser) -> T {
+pub fn with_error_checking_parse<F, T>(s: String, f: F) -> T where F: Fn(&mut Parser) -> T {
     let ps = new_parse_sess();
     let mut p = string_to_parser(&ps, s);
     let x = f(&mut p);

--- a/src/racer/method_info.rs
+++ b/src/racer/method_info.rs
@@ -1,0 +1,77 @@
+use syntax::ast::{FunctionRetTy, Method_};
+use syntax::ext::quote::rt::ToSource;
+use racer::ast::with_error_checking_parse;
+
+
+pub struct MethodInfo {
+    pub name : String,
+    pub output : Option<String>,
+    pub args : Vec<String>
+
+}
+
+impl MethodInfo {
+
+    ///Parses method declaration as string and returns relevant data
+    pub fn from_source_str(source : &str) -> MethodInfo {
+
+        let trim: &[_] = &['\n', '\r', '{', ' '];
+        let decorated = format!("{} {{}}()", source.trim_right_matches(trim));
+
+        with_error_checking_parse(decorated, |p| {
+
+            let ref method = p.parse_method_with_outer_attributes();
+
+            if let Method_::MethDecl(ident, _, _, _, _,ref decl, _, _) = method.node {
+                let mut args = Vec::new();
+                let mut out = None;
+
+                if let FunctionRetTy::Return(ref tp) = decl.output {
+                    out = Some(tp.to_source());
+                }
+
+                for arg in decl.inputs.iter() {
+                    args.push(arg.to_source());
+                }
+
+                return MethodInfo{ name:ident.to_source(), args:args, output:out};
+            }
+
+            panic!("Unable to parse method declaration.");
+        })
+    }
+
+    ///Returns completion snippets usable by some editors
+    pub fn snippet(&self) -> String {
+        let mut args = String::new();
+        let mut counter = 1;
+        for arg in self.args.iter() {
+            if arg.as_slice() == "self" {
+                continue;
+            }
+
+            if counter > 1 {
+                args.push_str(", ");
+            }
+
+            args.push_str(format!("${{{}:{}}}", counter, arg).as_slice());
+            counter = counter + 1;
+        }
+
+        return format!("{}({})", self.name, args);
+    }
+}
+
+
+#[test]
+fn method_info_test() {
+    let info = MethodInfo::from_source_str("pub fn new() -> Vec<T>");
+    assert_eq!(info.name, "new".as_slice());
+    assert_eq!(info.args.len(), 0);
+    assert_eq!(info.output, Some("Vec<T>".to_string()));
+
+    let info = MethodInfo::from_source_str("pub fn reserve(&mut self, additional: uint)");
+    assert_eq!(info.name, "reserve".as_slice());
+    assert_eq!(info.args.len(), 2);
+    assert_eq!(info.args[0].as_slice(), "self");
+}

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -12,7 +12,7 @@ pub mod codecleaner;
 pub mod testutils;
 pub mod util;
 pub mod matchers;
-pub mod method_info;
+pub mod snippets;
 
 #[cfg(test)] pub mod test;
 #[cfg(test)] pub mod bench;

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -11,6 +11,7 @@ pub mod codecleaner;
 pub mod testutils;
 pub mod util;
 pub mod matchers;
+pub mod method_info;
 
 #[cfg(test)] pub mod test;
 #[cfg(test)] pub mod bench;

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -1,19 +1,26 @@
 use syntax::ast::{FunctionRetTy, Method_};
 use syntax::ext::quote::rt::ToSource;
 use racer::ast::with_error_checking_parse;
+use racer::{Match, MatchType};
 
+pub fn snippet_for_match(m : &Match) -> String {
+    match m.mtype {
+        MatchType::Function => MethodInfo::from_source_str(&m.contextstr).snippet(),
+        _ => m.matchstr.clone()
+    }
+}
 
-pub struct MethodInfo {
-    pub name : String,
-    pub output : Option<String>,
-    pub args : Vec<String>
+struct MethodInfo {
+    name : String,
+    output : Option<String>,
+    args : Vec<String>
 
 }
 
 impl MethodInfo {
 
     ///Parses method declaration as string and returns relevant data
-    pub fn from_source_str(source : &str) -> MethodInfo {
+    fn from_source_str(source : &str) -> MethodInfo {
 
         let trim: &[_] = &['\n', '\r', '{', ' '];
         let decorated = format!("{} {{}}()", source.trim_right_matches(trim));
@@ -42,7 +49,7 @@ impl MethodInfo {
     }
 
     ///Returns completion snippets usable by some editors
-    pub fn snippet(&self) -> String {
+    fn snippet(&self) -> String {
         let mut args = String::new();
         let mut counter = 1;
         for arg in self.args.iter() {


### PR DESCRIPTION
I had to rethink my approach because SublimeText (and perhaps other editors) have some serious limitations regarding autocompletion.

The purpose of this MR is to add snippet to the function match, so that editors can paste it on completion. That snippet has placeholders for function arguments, so it is easier to fill them. I really like this feature and would like to have it for Rust.

I used ??? string to separate snippet from the rest of the match string, because both snippets and context may contain commas, which would mess splitting. I'm open to suggestions if you have better idea how to handle this.

The snippet format seems to be supported by popular editors, i.e. SublimeText, Atom, Emacs and Vim. Other editors should be able to adjust it to their needs.

![snippets](https://cloud.githubusercontent.com/assets/6204118/6070162/af1b4d38-ad8a-11e4-9b3c-cef1a576ec57.png)
After selecting completion you should be able to switch between arguments with TAB.
