### PR TITLE
Fixes for rustc 1.0.0-nightly (3ef8ff1f8 2015-02-12 00:38:24 +0000)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(collections, core, io, os, path, rustc_private, std_misc, env, test)]
+#![feature(collections, core, io, path, rustc_private, std_misc, env, test)]
 
 #[macro_use] extern crate log;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn match_fn(m:Match) {
 
 #[cfg(not(test))]
 fn complete(match_found : &Fn(Match)) {
-    let args = std::env::args().map(|a| a.into_string().unwrap()).collect::<Vec<_>>();
+    let args: Vec<String> = std::env::args().collect();
     if args.len() < 3 {
         println!("Provide more arguments!");
         print_usage();
@@ -102,7 +102,7 @@ fn complete(match_found : &Fn(Match)) {
 
 #[cfg(not(test))]
 fn prefix() {
-    let args = std::env::args().map(|a| a.into_string().unwrap()).collect::<Vec<_>>();
+    let args: Vec<String> = std::env::args().collect();
     if args.len() < 5 {
         println!("Provide more arguments!");
         print_usage();
@@ -122,7 +122,7 @@ fn prefix() {
 
 #[cfg(not(test))]
 fn find_definition() {
-    let args = std::env::args().map(|a| a.into_string().unwrap()).collect::<Vec<_>>();
+    let args: Vec<String> = std::env::args().collect();
     if args.len() < 5 {
         println!("Provide more arguments!");
         print_usage();
@@ -141,7 +141,7 @@ fn find_definition() {
 
 #[cfg(not(test))]
 fn print_usage() {
-    let program = std::env::args().next().unwrap().into_string().unwrap().clone();
+    let program = std::env::args().next().unwrap().clone();
     println!("usage: {} complete linenum charnum fname", program);
     println!("or:    {} find-definition linenum charnum fname", program);
     println!("or:    {} complete fullyqualifiedname   (e.g. std::io::)",program);
@@ -152,13 +152,13 @@ fn print_usage() {
 
 #[cfg(not(test))]
 fn main() {
-    if std::env::var_string("RUST_SRC_PATH").is_err() {
+    if std::env::var("RUST_SRC_PATH").is_err() {
         println!("RUST_SRC_PATH environment variable must be set");
         std::env::set_exit_status(1);
         return;
     }
 
-    let args = std::env::args().map(|a| a.into_string().unwrap()).collect::<Vec<_>>();
+    let args: Vec<String> = std::env::args().collect();
 
     if args.len() == 1 {
         print_usage();

--- a/src/racer/bench.rs
+++ b/src/racer/bench.rs
@@ -1,6 +1,6 @@
 extern crate test;
 
-use std::env::var_string;
+use std::env::var;
 use std::old_io::File;
 use self::test::Bencher;
 use racer::codecleaner::code_chunks;
@@ -9,7 +9,7 @@ use racer::scopes::{mask_comments, mask_sub_scopes};
 
 fn get_rust_file_str(path: &[&str]) -> String {
 
-    let mut src_path = match var_string("RUST_SRC_PATH") {
+    let mut src_path = match var("RUST_SRC_PATH") {
         Ok(env) => { Path::new(&env[]) },
         _ => panic!("Cannot find $RUST_SRC_PATH")
     };

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -916,7 +916,7 @@ pub fn resolve_path(path: &racer::Path, filepath: &Path, pos: usize,
     if len == 1 {
         let ref pathseg = path.segments[0];
         return resolve_name(pathseg, filepath, pos, search_type, namespace);
-    } else {
+    } else if len != 0 {
         let mut out = Vec::new();
         let mut parent_path: racer::Path = path.clone();
         parent_path.segments.remove(len-1);
@@ -968,6 +968,10 @@ pub fn resolve_path(path: &racer::Path, filepath: &Path, pos: usize,
         });
         debug!("resolve_path returning {:?}",out);
         return out.into_iter();
+    } else {
+        // TODO: Should this better be an assertion ? Why do we have a racer::Path
+        // with empty segments in the first place ?
+        return Vec::new().into_iter();
     }
 }
 

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -309,7 +309,7 @@ fn search_fn_args(fnstart: usize, open_brace_pos: usize, msrc:&str, searchstr:&s
 pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match> {
     debug!("do_file_search {}",searchstr);
     let mut out = Vec::new();
-    let srcpaths = std::env::var_string("RUST_SRC_PATH").unwrap_or("".to_string());
+    let srcpaths = std::env::var("RUST_SRC_PATH").unwrap_or("".to_string());
     debug!("do_file_search srcpaths {}",srcpaths);
     let mut v = (&srcpaths[]).split_str(PATH_SEP).collect::<Vec<_>>();
     v.push(currentdir.as_str().unwrap());
@@ -484,7 +484,7 @@ pub fn search_next_scope(mut startpoint: usize, pathseg: &racer::PathSegment,
 }
 
 pub fn get_crate_file(name: &str) -> Option<Path> {
-    let srcpaths = std::env::var_string("RUST_SRC_PATH").unwrap();
+    let srcpaths = std::env::var("RUST_SRC_PATH").unwrap();
     let v = (&srcpaths[]).split_str(PATH_SEP).collect::<Vec<_>>();
     for srcpath in v.into_iter() {
         {
@@ -758,7 +758,7 @@ pub fn search_prelude_file(pathseg: &racer::PathSegment, search_type: SearchType
     let mut out : Vec<Match> = Vec::new();
 
     // find the prelude file from the search path and scan it
-    let srcpaths = match std::env::var_string("RUST_SRC_PATH") { 
+    let srcpaths = match std::env::var("RUST_SRC_PATH") { 
         Ok(paths) => paths,
         Err(_) => return out.into_iter()
     };

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -45,10 +45,20 @@ impl MethodInfo {
 
     ///Returns completion snippets usable by some editors
     fn snippet(&self) -> String {
-        format!("{}({})", self.name, &self.args.iter()
-                .filter(|&s| &s[] != "self").enumerate()
-                .fold(String::new(), |cur, (i, ref s)| 
-                      cur + &format!(", ${{{}:{}}}", i+1, s)[])[2..])
+        let args: String = if self.args.len() > 0 {
+            self.args.iter()
+                    .filter(|&s| &s[] != "self")
+                    .enumerate()
+                    .fold(String::new(), |cur, (i, ref s)|
+                      cur + &format!(", ${{{}:{}}}", i+1, s)[])[2..].to_string()
+        } else {
+            // TODO: Figure out why this happens. It appears this happens when 
+            // constants are handled like a method
+            // produces matches like this one
+            // MATCH consts;consts;504;8;/Users/byron/Documents/dev/ext/rust-lang/rust/src/libstd/env.rs;Module;pub mod consts
+            "".to_string()
+        };
+        format!("{}({})", self.name, args)
     }
 }
 

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -45,9 +45,11 @@ impl MethodInfo {
 
     ///Returns completion snippets usable by some editors
     fn snippet(&self) -> String {
-        let args: String = if self.args.len() > 0 {
+        let args: String = 
+        if self.args.len() > 0 && 
+         !(self.args.len() == 1 && self.args[0] == "self")  {
             self.args.iter()
-                    .filter(|&s| &s[] != "self")
+                    .filter(|s| &s[] != "self")
                     .enumerate()
                     .fold(String::new(), |cur, (i, ref s)|
                       cur + &format!(", ${{{}:{}}}", i+1, s)[])[2..].to_string()

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -1,4 +1,5 @@
 // Small functions of utility
+use std::cmp;
 use std::old_io::{File, BufferedReader};
 use racer::{SearchType};
 use racer::SearchType::{ExactMatch, StartsWith};
@@ -97,6 +98,10 @@ fn txt_matches_matches_stuff() {
 
 
 pub fn expand_ident(s : &str, pos : usize) -> (usize,usize) {
+    // TODO: Would this better be an assertion ? Why are out-of-bound values getting here ?
+    // They are coming from the command-line, question is, if they should be handled beforehand
+    // clamp pos into allowed range
+    let pos = cmp::min(s.len(), pos);
     let sb = &s[..pos];
     let mut start = pos;
 


### PR DESCRIPTION
Even though this is a effective duplicate of #152, I use different syntax for the `env::args().collect()` calls.
Also there are some bugfixes, without which `racer` didn't work properly for me and `RustAutoComplete` (Sublime Text Plugin)