### PR TITLE
Improve matches

### DIFF
--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -42,12 +42,8 @@ pub fn scope_start(src:&str, point:usize) -> usize {
 pub fn find_stmt_start(msrc: &str, point: usize) -> Option<usize> {
     // iterate the scope to find the start of the statement
     let scopestart = scope_start(msrc, point);
-    for (start, end) in codeiter::iter_stmts(&msrc[scopestart..]) {
-        if (scopestart + end) > point {
-            return Some(scopestart+start);
-        }
-    }
-    None
+    codeiter::iter_stmts(&msrc[scopestart..]).filter_map(|(start, end)|
+        if scopestart+end > point { Some(scopestart+start) } else {None}).next()
 }
 
 pub fn get_local_module_path(msrc: &str, point: usize) -> Vec<String> {

--- a/src/racer/test.rs
+++ b/src/racer/test.rs
@@ -26,7 +26,7 @@ fn remove_file(tmppath:&Path) {
 #[test]
 fn completes_fn() {
     let src="
-    fn apple() {
+    fn   apple() {
     }
 
     fn main() {

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -64,13 +64,9 @@ pub fn txt_matches(stype: SearchType, needle: &str, haystack: &str) -> bool {
 }
 
 pub fn symbol_matches(stype: SearchType, searchstr: &str, candidate: &str) -> bool {
-   return match stype {
-        ExactMatch => {
-            return searchstr == candidate;
-        },
-        StartsWith => {
-            return candidate.starts_with(searchstr);
-        }
+   match stype {
+        ExactMatch => searchstr == candidate,
+        StartsWith => candidate.starts_with(searchstr)
     }
 }
 


### PR DESCRIPTION
Propose a better parsing in matchers (ie not necessarily separated with a simple space character)

It will do a better parsing of the first words in the blobs to ensure they match what is expected. They will also search for the `searchstr` directly and should prevent one parsing step.

In particular found that changing the first `complete_fn` test from

```Rust
fn apple

 to :
 
fn 
  apple
```
 broke the test.

NOTE: several matches have not been touched yet
