### PR TITLE
add Cargo lock and target/ folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ src/scopes
 !.travis.yml
 *tmpfile*
 *.racertmp
+Cargo.lock
+target/


### PR DESCRIPTION
Edit the ```.gitignore``` to make sure that git doesn't see files generated by Cargo

Prevents git from seeing the ```target/``` folder where your executables end up.

Also, ignore the ```Cargo.lock``` file that cargo creates for synchronization.