### PR TITLE
Fix build on current nightly (by removing threads from src/ast.rs)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(collections, core, io, path, rustc_private, std_misc, env, test)]
+#![feature(collections, core, old_io, old_path, rustc_private, env, test)]
 
 #[macro_use] extern crate log;
 


### PR DESCRIPTION
This fixes the build on the current nightly, and also #157, by simply removing all calls to `Thread::scoped` from `src/ast.rs`. All tests still pass, and no regressions have been found after some initial testing.