### PR TITLE
Use #![cfg_attr()] for declaring the exit_status and test features

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-#![feature(collections, core, old_io, old_path, rustc_private, exit_status)]
-#![feature(test)]   // need this for unit tests, but annoyingly puts a warning when building non-test
+#![feature(collections, core, old_io, old_path, rustc_private)]
+#![cfg_attr(not(test), feature(exit_status))] // we don't need exit_status feature when testing
+#![cfg_attr(test, feature(test))] // we only need test feature when testing
 
 
 #[macro_use] extern crate log;


### PR DESCRIPTION
This puts `#![feature(exit_status)]` under `#![cfg_attr(not(test))]`, and ``#![feature(test)]` under `#![cfg_attr(test)]` in order to be rid of all unused feature warnings.

`#![cfg_attr(..., ...)]` works just like `![cfg(...)]`, except for declaring attributes.