### PR TITLE
updated calls for libsyntax changes

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -37,7 +37,7 @@ pub fn with_error_checking_parse<F, T>(s: String, f: F) -> T where F: Fn(&mut Pa
 // parse a string, return an item
 pub fn string_to_item (source_str : String) -> Option<P<ast::Item>> {
     with_error_checking_parse(source_str, |p| {
-        p.parse_item(Vec::new())
+        p.parse_item()
     })
 }
 
@@ -45,7 +45,7 @@ pub fn string_to_item (source_str : String) -> Option<P<ast::Item>> {
 pub fn string_to_stmt(source_str : String) -> P<ast::Stmt> {
     with_error_checking_parse(source_str, |p| {
 
-        p.parse_stmt(Vec::new())
+        p.parse_stmt().unwrap()
     })
 }
 

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -28,7 +28,7 @@ impl MethodInfo {
         let decorated = format!("{} {{}}()", source.trim_right_matches(trim));
 
         with_error_checking_parse(decorated, |p| {
-            let ref method = p.parse_impl_item_with_outer_attributes();
+            let ref method = p.parse_impl_item();
 
             match method.node {
                 ImplItem_::MethodImplItem(ref msig, _) => {


### PR DESCRIPTION
`Parser::parse_item` and `Parser::parse_stmt` lost a parameter each. Also, `Parser::parse_stmt` now returns an `Option`. Changes made were ripped from the updated `libsyntax::util::parser_testing`, just like the original.