### PR TITLE
Fix build error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![feature(collections, core, rustc_private, str_char)]
 #![cfg_attr(not(test), feature(exit_status))] // we don't need exit_status feature when testing
-#![cfg_attr(test, feature(test))] // we only need test feature when testing
+#![cfg_attr(test, feature(convert, test))] // we only need test feature when testing
 
 
 #[macro_use] extern crate log;

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -722,7 +722,7 @@ impl<'v> visit::Visitor<'v> for ExternCrateVisitor {
     fn visit_item(&mut self, item: &ast::Item) {
         if let ast::ItemExternCrate(ref optional_s) = item.node {
             self.name = Some(String::from_str(&token::get_ident(item.ident)));
-            if let &Some((ref istr, _)) = optional_s {
+            if let &Some(ref istr) = optional_s {
                 self.realname = Some(istr.to_string());
             }
         }

--- a/src/racer/bench.rs
+++ b/src/racer/bench.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 fn get_rust_file_str(path: &[&str]) -> String {
 
     let mut src_path = match var("RUST_SRC_PATH") {
-        Ok(env) => { PathBuf::new(&env) },
+        Ok(env) => { PathBuf::from(&env) },
         _ => panic!("Cannot find $RUST_SRC_PATH")
     };
     for &s in path.iter() { src_path.push(s); }

--- a/src/racer/test.rs
+++ b/src/racer/test.rs
@@ -13,7 +13,7 @@ fn tmpname() -> PathBuf {
     let s = taskname.replace("::","_"); 
     let mut p = String::from_str("tmpfile.");
     p.push_str(&s[..]);
-    PathBuf::new(p)
+    PathBuf::from(p)
 }
 
 fn write_file(tmppath:&Path, s : &str) {
@@ -350,7 +350,6 @@ fn follows_self_use() {
     }
     ";
     let basedir = tmpname();
-    fs::create_dir(&basedir).unwrap();
     let moddir = basedir.join("mymod");
     fs::create_dir_all(&moddir).unwrap();
 
@@ -383,7 +382,6 @@ fn finds_nested_submodule_file() {
     ";
 
     let basedir = tmpname();
-    fs::create_dir(&basedir).unwrap();
     let srcpath = basedir.join("root.rs");
     let sub2dir = basedir.join("sub1").join("sub2");
     fs::create_dir_all(&sub2dir).unwrap();


### PR DESCRIPTION
Fixes #181 along errors in the tests. I also removed a few `create_dir` calls that I added in the last PR, because they were simply workarounds to a bug that has now been fixed in rust.