### PR TITLE
Show signature of functions in vim popup menu

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -100,8 +100,17 @@ function! racer#GetCompletions()
     let out = []
     for line in lines
        if line =~ "^MATCH"
-           let completion = split(line[6:], ",")[0]
-           let out = add(out, completion)
+           let line_parts = split(line[6:], ",")
+           let name = line_parts[0]
+	   let kind = ""
+           let type = ""
+	   if line_parts[4] == "StructField"
+	       let kind = "m"
+           elseif line_parts[4] == "Function"
+	       let kind = "f"
+               let type = join(line_parts[5:], ",")
+	   endif
+           let out = add(out, {'word': name, 'kind': kind, 'menu': type})
        endif
     endfor
     call delete(tmpfname)


### PR DESCRIPTION
e.g. for the 'Vec' type and the string 'push' the
popup menu previously only showed:

   push
   push_all

Now the popup menu will show:

   push     f pub fn push(&mut self, value: T)
   push_all f pub fn push_all(&mut self, other: &[T])

Currently functions get a 'f' marker and struct members a 'm'.