### PR TITLE
Depend on `syntex_syntax` rather than `syntax`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,7 @@
 language: rust
+rust:
+  - nightly
+  - 1.0.0-beta
+matrix:
+  allow_failures:
+    - rust: 1.0.0-beta

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,34 @@
 name = "racer"
 version = "0.0.1"
 dependencies = [
+ "syntex_syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -11,10 +38,54 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "syntex_fmt_macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syntex_syntax"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_fmt_macros 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "toml"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ path = "src/main.rs"
 debug = true
 
 [dependencies]
-toml = "0.1.19"
+syntex_syntax = "*"
+toml = "*"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Important - Racer does not work with Rust Beta!
 
-Racer uses unstable features from the standard library, and so currently requires a rust nightly install 
+Racer uses unstable features from the standard library, and so currently requires a rust nightly install
 
 ## Installation
 
@@ -18,7 +18,7 @@ Racer uses unstable features from the standard library, and so currently require
 
    (e.g. ```% export RUST_SRC_PATH=/usr/local/src/rust/src``` )
 
-3. Test on the command line: 
+3. Test on the command line:
 
    ```./target/release/racer complete std::io::B ```  (should show some completions)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # *Racer* - code completion for [Rust](http://www.rust-lang.org/)
 
+[![Build Status](https://travis-ci.org/phildawes/racer.svg?branch=master)](https://travis-ci.org/phildawes/racer)
+
 ![alt text](https://github.com/phildawes/racer/raw/master/images/racer1.png "Racer emacs session")
 
 *RACER* = *R*ust *A*uto-*C*omplete-*er*. A utility intended to provide rust code completion for editors and IDEs. Maybe one day the 'er' bit will be exploring + refactoring or something.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@
 
 #[macro_use] extern crate log;
 
-extern crate syntax;
 extern crate collections;
 extern crate core;
+extern crate syntex_syntax;
 extern crate toml;
 
 #[cfg(not(test))]

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -1,5 +1,3 @@
-extern crate syntax;
-
 use racer::{self, typeinf, Match, MatchType, Scope, Ty};
 use racer::nameres::{self, resolve_path_with_str};
 use racer::Ty::{TyTuple, TyPathSearch, TyMatch, TyUnsupported};
@@ -7,15 +5,12 @@ use racer::Ty::{TyTuple, TyPathSearch, TyMatch, TyUnsupported};
 use std::ops::Deref;
 use std::path::Path;
 
-use syntax::ast;
-use syntax::codemap;
-use syntax::parse::{new_parse_sess, ParseSess, string_to_filemap};
-use syntax::parse::parser::Parser;
-use syntax::parse::token;
-use syntax::parse::lexer;
-use syntax::ptr::P;
-use syntax::visit::{self, Visitor};
-use syntax::diagnostic::FatalError;
+use syntex_syntax::ast;
+use syntex_syntax::codemap;
+use syntex_syntax::parse::parser::Parser;
+use syntex_syntax::parse::{lexer, new_parse_sess, ParseSess, string_to_filemap, token};
+use syntex_syntax::ptr::P;
+use syntex_syntax::visit::{self, Visitor};
 
 // This code ripped from libsyntax::util::parser_testing
 pub fn string_to_parser<'a>(ps: &'a ParseSess, source_str: String) -> Option<Parser<'a>> {
@@ -38,6 +33,7 @@ pub fn with_error_checking_parse<F, T>(s: String, f: F) -> Option<T> where F: Fn
 // parse a string, return a stmt
 pub fn string_to_stmt(source_str : String) -> Option<P<ast::Stmt>> {
     with_error_checking_parse(source_str, |p| {
+        use syntex_syntax::diagnostic::FatalError;
         match p.parse_stmt_nopanic() {
             Ok(p) => p,
             Err(FatalError) => None
@@ -49,7 +45,7 @@ pub fn string_to_stmt(source_str : String) -> Option<P<ast::Stmt>> {
 pub fn string_to_crate (source_str : String) -> Option<ast::Crate> {
     with_error_checking_parse(source_str.clone(), |p| {
         use std::result::Result::{Ok, Err};
-        use syntax::diagnostic::FatalError;
+        use syntex_syntax::diagnostic::FatalError;
         match p.parse_crate_mod() {
             Ok(e) => Some(e),
             Err(FatalError) => {

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -2,7 +2,7 @@ use racer::ast::with_error_checking_parse;
 use racer::{Match, MatchType};
 use racer::typeinf::get_function_declaration;
 
-use syntax::ast::{ImplItem_};
+use syntex_syntax::ast::ImplItem_;
 
 pub fn snippet_for_match(m : &Match) -> String {
     match m.mtype {
@@ -32,7 +32,7 @@ impl MethodInfo {
         with_error_checking_parse(decorated, |p| {
 
             use std::result::Result::{Ok, Err};
-            use syntax::diagnostic::FatalError;
+            use syntex_syntax::diagnostic::FatalError;
             match p.parse_impl_item() {
                 Ok(method) => {
                     match method.node {


### PR DESCRIPTION
Probably won't solve #202 due to https://github.com/erickt/rust-syntex/issues/2