### PR TITLE
Fix bench compilation error.

### DIFF
--- a/src/racer/bench.rs
+++ b/src/racer/bench.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "nightly")]
 mod racer_bench {
+    extern crate test;
+
     use racer::codecleaner::code_chunks;
     use racer::codeiter::iter_stmts;
     use racer::scopes::{mask_comments, mask_sub_scopes};


### PR DESCRIPTION
Add 'extern crate test' removed by mistake in 93954f697baa50df2f010da54acb9d825082d15c.