### PR TITLE
Use `Vec::extend` instead of binary operation `+`.

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -620,9 +620,9 @@ pub fn search_scope(start: usize, point: usize, src: &str,
         }
 
         // There's a good chance of a match. Run the matchers
-        out = out + &*run_matchers_on_blob(src, start+blobstart, start+blobend,
-                                      searchstr,
-                                      filepath, search_type, local, namespace);
+        out.extend(run_matchers_on_blob(src, start+blobstart, start+blobend,
+                                        searchstr,
+                                        filepath, search_type, local, namespace));
         if let ExactMatch = search_type {
             if !out.is_empty() {
                 return out.into_iter();


### PR DESCRIPTION
This fixes a compilation error on the latest nightly (`rustc 1.1.0-nightly (c033d9828 2015-05-09) (built 2015-05-08)`):

```
src/racer/nameres.rs:623:15: 623:18 error: binary operation `+` cannot be applied to type `collections::vec::Vec<racer::Match>` [E0369]
src/racer/nameres.rs:623         out = out + &*run_matchers_on_blob(src, start+blobstart, start+blobend,
                                       ^~~
error: aborting due to previous error
Could not compile `racer`.
```