### PR TITLE
Add missing :endif

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -149,6 +149,7 @@ function! racer#Complete(findstart, base)
             return racer#GetExpCompletions()
         else
             return racer#GetCompletions()
+        endif
     endif
 endfunction
 


### PR DESCRIPTION
`if` statement in Vim script must be ended with `:endif`.