### PR TITLE
vim plugin open definition in a split not buffer

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -135,7 +135,7 @@ endfunction
 function! RacerJumpToLocation(filename, linenum, colnum)
     if(a:filename != '')
         if a:filename != bufname('%')
-            exec 'e ' . fnameescape(a:filename)
+            exec 'vsp ' . fnameescape(a:filename)
         endif
         call cursor(a:linenum, a:colnum+1)
     endif


### PR DESCRIPTION
Seems nicer for me? Opens a vertical split instead of a new buffer for the definition after 'gd'