### PR TITLE
Handle crate structure edge cases

### DIFF
--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -86,7 +86,17 @@ fn get_versioned_cratefile(kratename: &str, version: &str) -> Option<PathBuf> {
     d = otry!(find_cratesio_src_dir(d));
     d.push(kratename.to_string() + "-" + &version);
     d.push("src");
+
+    // First, check for package name at root (src/kratename/lib.rs)
+    d.push(kratename.to_string());
+    if let Err(_) = File::open(&d) {
+        // It doesn't exist, so assume src/lib.rs
+        d.pop();
+    }
     d.push("lib.rs");
+    if let Err(_) = File::open(&d) {
+        return None;
+    }
 
     Some(d)
  }

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -219,7 +219,11 @@ impl fmt::Debug for PathSearch {
 
 pub fn load_file(filepath: &path::Path) -> String {
     let mut rawbytes = Vec::new();
-    BufReader::new(File::open(filepath).unwrap()).read_to_end(&mut rawbytes).unwrap();
+    if let Ok(f) = File::open(filepath) {
+        BufReader::new(f).read_to_end(&mut rawbytes).unwrap();
+    } else {
+        return "".to_string();
+    }
 
     // skip BOF bytes, if present
     if rawbytes[0..3] == [0xEF, 0xBB, 0xBF] {


### PR DESCRIPTION
This PR fixes two bugs which I ran into when using completions on the SDL2 and GL crates. Specifically, when a crate uses an additional root directory under `src` for its root module, racer would not correctly handle it, and would panic because `lib.rs` did not exist in the place it expected it to.