### PR TITLE
Clean nameres

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -32,28 +32,12 @@ pub fn with_error_checking_parse<F, T>(s: String, f: F) -> Option<T> where F: Fn
 
 // parse a string, return a stmt
 pub fn string_to_stmt(source_str: String) -> Option<P<ast::Stmt>> {
-    with_error_checking_parse(source_str, |p| {
-        use syntex_syntax::diagnostic::FatalError;
-        match p.parse_stmt_nopanic() {
-            Ok(p) => p,
-            Err(FatalError) => None
-        }
-    })
+    with_error_checking_parse(source_str, |p| p.parse_stmt_nopanic().unwrap_or(None))
 }
 
 // parse a string, return a crate.
-pub fn string_to_crate (source_str: String) -> Option<ast::Crate> {
-    with_error_checking_parse(source_str.clone(), |p| {
-        use std::result::Result::{Ok, Err};
-        use syntex_syntax::diagnostic::FatalError;
-        match p.parse_crate_mod() {
-            Ok(e) => Some(e),
-            Err(FatalError) => {
-                debug!("unable to parse crate. Returning None |{}|", source_str);
-                None
-            }
-        }
-    })
+pub fn string_to_crate(source_str: String) -> Option<ast::Crate> {
+    with_error_checking_parse(source_str.clone(), |p| p.parse_crate_mod().ok())
 }
 
 

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -104,15 +104,12 @@ impl<'v> visit::Visitor<'v> for LetVisitor {
     }
 
     fn visit_pat(&mut self, p: &'v ast::Pat) {
-        match p.node {
-            ast::PatIdent(_ , ref spannedident, _) => {
-                let codemap::BytePos(lo) = spannedident.span.lo;
-                let codemap::BytePos(hi) = spannedident.span.hi;
-                self.ident_points.push((lo as usize, hi as usize));
-            }
-            _ => {
-                visit::walk_pat(self, p);
-            }
+        if let ast::PatIdent(_ , ref spannedident, _) = p.node {
+            let codemap::BytePos(lo) = spannedident.span.lo;
+            let codemap::BytePos(hi) = spannedident.span.hi;
+            self.ident_points.push((lo as usize, hi as usize));
+        } else {
+            visit::walk_pat(self, p);
         }
     }
 }

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -80,16 +80,7 @@ fn match_pattern_start(src: &str, blobstart: usize, blobend: usize,
     if let Some(start) = find_keyword(blob, pattern, searchstr, search_type, local) {
         if let Some(end) = blob[start..].find(':') {
             let s = &blob[start..start+end].trim_right();
-            return Some(Match {
-                matchstr: s.to_string(),
-                filepath: filepath.to_path_buf(),
-                point: blobstart+start,
-                local: local,
-                mtype: mtype,
-                contextstr: first_line(blob),
-                generic_args: Vec::new(),
-                generic_types: Vec::new()
-            })
+            return Some(Match::new(s, filepath, blobstart+start, local, mtype, &first_line(blob)));
         }
     }
     None
@@ -120,15 +111,8 @@ fn match_pattern_let(msrc: &str, blobstart: usize, blobend: usize,
             let s = &blob[start..end];
             if symbol_matches(search_type, searchstr, s) {
                 debug!("match_pattern_let point is {}", blobstart + start);
-                out.push(Match { matchstr: s.to_string(),
-                                   filepath: filepath.to_path_buf(),
-                                   point: blobstart + start,
-                                   local: local,
-                                   mtype: mtype,
-                                   contextstr: first_line(blob),
-                                   generic_args: Vec::new(),
-                                   generic_types: Vec::new()
-                         });
+                out.push(Match::new(s, filepath, blobstart + start, local, 
+                                    mtype, &first_line(blob)));
                 if let ExactMatch = search_type {
                     break;
                 }
@@ -192,16 +176,8 @@ pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
                 } else {
                     name
                 };
-            get_crate_file(&realname, filepath).map(|cratepath| {
-                res = Some(Match { matchstr: name.clone(),
-                                  filepath: cratepath.to_path_buf(),
-                                  point: 0,
-                                  local: false,
-                                  mtype: Module,
-                                  contextstr: cratepath.to_str().unwrap().to_string(),
-                                  generic_args: Vec::new(),
-                                  generic_types: Vec::new()
-                });
+            get_crate_file(&realname, filepath).map(|ref cratepath| {
+                res = Some(Match::new(name, cratepath, 0, false, Module, cratepath.to_str().unwrap()));
             });
         }
     }
@@ -221,17 +197,8 @@ pub fn match_mod(msrc: &str, blobstart: usize, blobend: usize,
 
         if blob.find('{').is_some() {
             debug!("found an inline module!");
-
-            return Some(Match {
-                matchstr: l.to_string(),
-                filepath: filepath.to_path_buf(),
-                point: blobstart + start,
-                local: false,
-                mtype: Module,
-                contextstr: filepath.to_str().unwrap().to_string(),
-                generic_args: Vec::new(),
-                generic_types: Vec::new()
-            })
+            return Some(Match::new(l, filepath, blobstart + start, false, Module, 
+                filepath.to_str().unwrap()));
         } else {
             // get internal module nesting
             // e.g. is this in an inline submodule?  mod foo{ mod bar; }
@@ -242,17 +209,9 @@ pub fn match_mod(msrc: &str, blobstart: usize, blobend: usize,
             for s in internalpath {
                 searchdir.push(&s);
             }
-            if let Some(modpath) = get_module_file(l, &searchdir) {
-                return Some(Match {
-                    matchstr: l.to_string(),
-                    filepath: modpath.to_path_buf(),
-                    point: 0,
-                    local: false,
-                    mtype: Module,
-                    contextstr: modpath.to_str().unwrap().to_string(),
-                    generic_args: Vec::new(),
-                    generic_types: Vec::new()
-                })
+            if let Some(ref modpath) = get_module_file(l, &searchdir) {
+                return Some(Match::new(l, modpath, 0, false, Module, 
+                    modpath.to_str().unwrap()));
             }
         }
     }
@@ -275,17 +234,16 @@ pub fn match_struct(msrc: &str, blobstart: usize, blobend: usize,
             .expect("Can't find end of struct header");
         // structs with no values need to end in ';', not '{}'
         let generics = ast::parse_generics(format!("{};", &blob[..end]));
-
         Some(Match {
-            matchstr: l.to_string(),
-            filepath: filepath.to_path_buf(),
+            matchstr: l.to_owned(),
+            filepath: filepath.to_owned(),
             point: blobstart + start,
             local: local,
             mtype: Struct,
             contextstr: first_line(blob),
             generic_args: generics.generic_args,
             generic_types: Vec::new()
-        })
+        })        
     } else {
         None
     }
@@ -301,16 +259,7 @@ pub fn match_type(msrc: &str, blobstart: usize, blobend: usize,
             StartsWith => &blob[start..find_ident_end(blob, start+searchstr.len())]
         };
         debug!("found!! a type {}", l);
-        Some(Match {
-            matchstr: l.to_string(),
-            filepath: filepath.to_path_buf(),
-            point: blobstart + start,
-            local: local,
-            mtype: Type,
-            contextstr: first_line(blob),
-            generic_args: Vec::new(),
-            generic_types: Vec::new()
-        })
+        Some(Match::new(l, filepath, blobstart + start, local, Type, &first_line(blob)))
     } else {
         None
     }
@@ -326,16 +275,7 @@ pub fn match_trait(msrc: &str, blobstart: usize, blobend: usize,
             StartsWith => &blob[start..find_ident_end(blob, start+searchstr.len())]
         };
         debug!("found!! a trait {}", l);
-        Some(Match {
-            matchstr: l.to_string(),
-            filepath: filepath.to_path_buf(),
-            point: blobstart + start,
-            local: local,
-            mtype: Trait,
-            contextstr: first_line(blob),
-            generic_args: Vec::new(),
-            generic_types: Vec::new()
-        })
+        Some(Match::new(l, filepath, blobstart + start, local, Trait, &first_line(blob)))
     } else {
         None
     }
@@ -353,17 +293,8 @@ pub fn match_enum_variants(msrc: &str, blobstart: usize, blobend: usize,
 
             for (name, offset) in parsed_enum.values.into_iter() {
                 if (&name).starts_with(searchstr) {
-                    let m = Match {
-                        matchstr: name.clone(),
-                        filepath: filepath.to_path_buf(),
-                        point: blobstart + offset,
-                        local: local,
-                        mtype: EnumVariant,
-                        contextstr: first_line(&blob[offset..]),
-                        generic_args: Vec::new(),
-                        generic_types: Vec::new()
-                    };
-                    out.push(m);
+                    out.push(Match::new(&name, filepath, blobstart + offset, local, 
+                                        EnumVariant, &first_line(&blob[offset..])));
                 }
             }
         }
@@ -385,10 +316,9 @@ pub fn match_enum(msrc: &str, blobstart: usize, blobend: usize,
         let end = blob.find('{').or(blob.find(';'))
             .expect("Can't find end of enum header");
         let generics = ast::parse_generics(format!("{}{{}}", &blob[..end]));
-
         Some(Match {
-            matchstr: l.to_string(),
-            filepath: filepath.to_path_buf(),
+            matchstr: l.to_owned(),
+            filepath: filepath.to_owned(),
             point: blobstart + start,
             local: local,
             mtype: Enum,
@@ -512,16 +442,7 @@ pub fn match_fn(msrc: &str, blobstart: usize, blobend: usize,
                 StartsWith => &blob[start..find_ident_end(blob, start+searchstr.len())]
             };
             debug!("found a fn {}", l);
-            Some(Match {
-                matchstr: l.to_string(),
-                filepath: filepath.to_path_buf(),
-                point: blobstart + start,
-                local: local,
-                mtype: Function,
-                contextstr: first_line(blob),
-                generic_args: Vec::new(),
-                generic_types: Vec::new()
-            })
+            Some(Match::new(l, filepath, blobstart + start, local, Function, &first_line(blob)))
         } else {
             None
         }

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -436,7 +436,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
             if follow_glob {
                 ALREADY_GLOBBING.with(|c| { c.set(Some(true)) });
 
-                let seg = PathSegment{ name: searchstr.to_string(), types: Vec::new() };
+                let seg = PathSegment::new(searchstr);
                 let mut path = basepath.clone();
                 path.segments.push(seg);
                 debug!("found a glob: now searching for {:?}", path);

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -221,21 +221,17 @@ impl fmt::Debug for PathSearch {
 }
 
 pub fn load_file(filepath: &path::Path) -> String {
-    let mut rawbytes = Vec::new();
-    if let Ok(f) = File::open(filepath) {
+    File::open(filepath).ok().map_or("".to_string(), |f| {
+        let mut rawbytes = Vec::new();
         BufReader::new(f).read_to_end(&mut rawbytes).unwrap();
-    } else {
-        return "".to_string();
-    }
 
-    // skip BOF bytes, if present
-    if rawbytes[0..3] == [0xEF, 0xBB, 0xBF] {
-        let mut it = rawbytes.into_iter();
-        it.next(); it.next(); it.next();
-        return String::from_utf8(it.collect::<Vec<_>>()).unwrap();
-    } else {
-        return String::from_utf8(rawbytes).unwrap();
-    }
+        // skip BOF bytes, if present
+        if rawbytes[0..3] == [0xEF, 0xBB, 0xBF] {
+            String::from_utf8(rawbytes.into_iter().skip(3).collect()).unwrap()
+        } else {
+            String::from_utf8(rawbytes).unwrap()
+        }
+    })
 }
 
 pub fn load_file_and_mask_comments(filepath: &path::Path) -> String {
@@ -249,46 +245,32 @@ pub fn load_file_and_mask_comments(filepath: &path::Path) -> String {
 pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize) -> vec::IntoIter<Match> {
     let start = scopes::get_start_of_search_expr(src, pos);
     let expr = &src[start..pos];
+    let search_type = SearchType::StartsWith;
 
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
 
     debug!("{:?}: contextstr is |{}|, searchstr is |{}|", completetype, contextstr, searchstr);
 
-    let mut out = Vec::new();
-
     match completetype {
         CompletionType::CompletePath => {
-            let mut v = expr.split("::").collect::<Vec<_>>();
-            let mut global = false;
-            if v[0] == "" {      // i.e. starts with '::' e.g. ::std::old_io::blah
-                v.remove(0);
-                global = true;
-            }
-
-            let path = Path::from_vec(global, v);
-            for m in nameres::resolve_path(&path, filepath, pos,
-                                         SearchType::StartsWith, Namespace::BothNamespaces) {
-                out.push(m);
-            }
+            let global = expr.starts_with("::"); // e.g. ::std::old_io::blah
+            let v = (if global { &expr[2..] } else { expr }).split("::").collect();
+            nameres::resolve_path(&Path::from_vec(global, v), filepath, pos,
+                                  search_type, Namespace::BothNamespaces)
         },
         CompletionType::CompleteField => {
             let context = ast::get_type_of(contextstr.to_string(), filepath, pos);
             debug!("complete_from_file context is {:?}", context);
-            context.map(|ty| {
-                match ty {
-                    Ty::TyMatch(m) => {
-                        for m in nameres::search_for_field_or_method(m, searchstr, SearchType::StartsWith) {
-                            out.push(m)
-                        }
-                    }
-                    _ => {}
+            context.map_or(Vec::new().into_iter(), |ty| {
+                if let Ty::TyMatch(m) = ty {
+                    nameres::search_for_field_or_method(m, searchstr, search_type)
+                } else {
+                    Vec::new().into_iter()
                 }
-            });
+            })
         }
     }
-    out.into_iter()
 }
-
 
 pub fn find_definition(src: &str, filepath: &path::Path, pos: usize) -> Option<Match> {
     find_definition_(src, filepath, pos)
@@ -297,42 +279,31 @@ pub fn find_definition(src: &str, filepath: &path::Path, pos: usize) -> Option<M
 pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize) -> Option<Match> {
     let (start, end) = scopes::expand_search_expr(src, pos);
     let expr = &src[start..end];
+    let search_type = SearchType::ExactMatch;
 
     let (contextstr, searchstr, completetype) = scopes::split_into_context_and_completion(expr);
 
     debug!("find_definition_ for |{:?}| |{:?}| {:?}", contextstr, searchstr, completetype);
 
-    return match completetype {
+    match completetype {
         CompletionType::CompletePath => {
-            let mut v = expr.split("::").collect::<Vec<_>>();
-            let mut global = false;
-            if v[0] == "" {      // i.e. starts with '::' e.g. ::std::old_io::blah
-                v.remove(0);
-                global = true;
-            }
-
-            let segs = v
-                .iter()
-                .map(|x| PathSegment::new(*x))
-                .collect::<Vec<_>>();
-            let path = Path{ global: global, segments: segs };
-
-            return nameres::resolve_path(&path, filepath, pos,
-                                         SearchType::ExactMatch, Namespace::BothNamespaces).nth(0);
+            let global = expr.starts_with("::"); // e.g. ::std::old_io::blah
+            let v = (if global { &expr[2..] } else { expr }).split("::").collect();
+            nameres::resolve_path(&Path::from_vec(global, v), filepath, pos,
+                                  search_type, Namespace::BothNamespaces).next()
         },
         CompletionType::CompleteField => {
             let context = ast::get_type_of(contextstr.to_string(), filepath, pos);
             debug!("context is {:?}", context);
 
-            return context.and_then(|ty| {
+            context.and_then(|ty| {
                 // for now, just handle matches
-                match ty {
-                    Ty::TyMatch(m) => {
-                        return nameres::search_for_field_or_method(m, searchstr, SearchType::ExactMatch).nth(0);
-                    }
-                    _ => None
+                if let Ty::TyMatch(m) = ty {
+                    nameres::search_for_field_or_method(m, searchstr, search_type).next()
+                } else {
+                    None
                 }
-            });
+            })
         }
     }
 }

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -79,6 +79,21 @@ pub struct Match {
 
 
 impl Match {
+
+    fn new<P: AsRef<path::Path>>(matchstr: &str, path: P, point: usize, 
+           local: bool, mtype: MatchType, context: &str) -> Match {
+        Match {
+            matchstr: matchstr.to_owned(),
+            filepath: path.as_ref().to_owned(),
+            point: point,
+            local: local,
+            mtype: mtype,
+            contextstr: context.to_owned(),
+            generic_args: Vec::new(),
+            generic_types: Vec::new()
+        }
+    }
+
     fn with_generic_types(&self, generic_types: Vec<PathSearch>) -> Match {
         Match {
             matchstr: self.matchstr.clone(),

--- a/src/racer/mod.rs
+++ b/src/racer/mod.rs
@@ -151,7 +151,7 @@ impl Path {
     pub fn from_vec(global: bool, v: Vec<&str>) -> Path {
         let segs = v
             .iter()
-            .map(|x| PathSegment{ name:x.to_string(), types: Vec::new() })
+            .map(|x| PathSegment::new(x) )
             .collect::<Vec<_>>();
         Path{ global: global, segments: segs }
     }
@@ -199,6 +199,12 @@ impl fmt::Debug for Path {
 pub struct PathSegment {
     pub name: String,
     pub types: Vec<Path>
+}
+
+impl PathSegment {
+    fn new(name: &str) -> PathSegment {
+        PathSegment { name: name.to_owned(), types: Vec::new() }
+    }
 }
 
 #[derive(Clone)]
@@ -310,7 +316,7 @@ pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize) -> Option<
 
             let segs = v
                 .iter()
-                .map(|x| PathSegment{ name: x.to_string(), types: Vec::new() })
+                .map(|x| PathSegment::new(x) )
                 .collect::<Vec<_>>();
             let path = Path{ global: global, segments: segs };
 

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -139,8 +139,8 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: &str, searchstr: 
                 for m in out.iter_mut() {
                     m.point += ifletstart;
                 }
-                out.into_iter()
-            } else { Vec::new().into_iter() }
+                out
+            } else { Vec::new() }
         } else if let Some(n) = util::find_last_str("match ", preblock) {
             // TODO: this code is crufty. refactor me!
             let matchstart = stmtstart + n;
@@ -190,18 +190,12 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: &str, searchstr: 
                 }
             });
             match search_type {
-                ExactMatch => {
-                    if let Some(m) = matches.next() {
-                        vec![m].into_iter()
-                    } else {
-                        Vec::new().into_iter()
-                    }
-                }
-                StartsWith => matches.collect::<Vec<_>>().into_iter()
+                ExactMatch => matches.next().map_or(Vec::new(), |m| vec![m]),
+                StartsWith => matches.collect::<Vec<_>>()
             }
         } else {
-           Vec::new().into_iter()
-        }
+           Vec::new()
+        }.into_iter()
     })
 
 }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -308,7 +308,7 @@ pub fn search_crate_root(pathseg: &racer::PathSegment, modfpath: &Path,
         });
 
     match searchtype {
-        ExactMatch => matches.next().map_or(Vec::new().into_iter(), |m| vec![m].into_iter()),
+        ExactMatch => matches.next().map_or(Vec::new(), |m| vec![m]).into_iter(),
         StartsWith => matches
     }
 }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -716,7 +716,7 @@ pub fn get_super_scope(filepath: &Path, pos: usize) -> Option<racer::Scope> {
         Some(racer::Scope{ filepath: filepath.to_owned(), point: 0 })
     } else {
         path.pop();
-        let path = racer::Path::from_svec(false, path);
+        let path = racer::Path::from_vec(false, path);
         debug!("get_super_scope looking for local scope {:?}", path);
         resolve_path(&path, filepath, 0, SearchType::ExactMatch, Namespace::TypeNamespace)
             .next()

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -665,15 +665,7 @@ pub struct Search {
 }
 
 pub fn is_a_repeat_search(new_search: &Search) -> bool {
-    SEARCH_STACK.with(|v| {
-        for s in v.iter() {
-            if s == new_search {
-                debug!("is a repeat search {:?} Stack: {:?}", new_search, v);
-                return true;
-            }
-        }
-        false
-    })
+    SEARCH_STACK.with(|v| v.iter().any(|s| s == new_search))
 }
 
 pub fn resolve_name(pathseg: &racer::PathSegment, filepath: &Path, pos: usize,


### PR DESCRIPTION
Lot of changes to *nameres.rs*.
I have splitted all commits so I can probably revert the ones you don't like.

Main changes are:
- add constructors for `Match` and `PathSegment`
- use more iterator constructs, with the benefits:
  - do not check for `ExactMatch` for each item
  - use extend whenever possible
  - sometimes do not even create intermediary vector, just return the existing `vec::IntoIter`
  - most of the time, it is shorter. It looks easier to read for me


I haven't modified the biggest function `search_scope` because the alternatives I found didn't look good.

If needed I can squash it.