### PR TITLE
search for underscored names in lock files

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -42,7 +42,7 @@ pub fn string_to_stmt(source_str: String) -> Option<P<ast::Stmt>> {
 }
 
 // parse a string, return a crate.
-pub fn string_to_crate (source_str: String) -> Option<ast::Crate> {
+pub fn string_to_crate(source_str: String) -> Option<ast::Crate> {
     with_error_checking_parse(source_str.clone(), |p| {
         use std::result::Result::{Ok, Err};
         use syntex_syntax::diagnostic::FatalError;

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -32,21 +32,24 @@ fn find_src_via_lockfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
 
     for item in t {
         if let &toml::Value::Table(ref t) = item {
-            if Some(&toml::Value::String(kratename.to_string())) == t.get("name") {
-                let version = otry!(getstr(t, "version"));
-                let source = otry!(getstr(t, "source"));
+            if let Some(&toml::Value::String(ref name)) = t.get("name") {
+                if name.replace("-", "_") == kratename {
+                    debug!("found matching crate {:?}", t);
+                    let version = otry!(getstr(t, "version"));
+                    let source = otry!(getstr(t, "source"));
 
-                if Some("registry") == source.split("+").nth(0) {
-                    return get_versioned_cratefile(kratename, &version);
-                } else if Some("git") == source.split("+").nth(0) {
-                    let sha1 = otry!(source.split("#").last());
-                    let mut d = otry!(get_cargo_rootdir());
-                    d.push("git");
-                    d.push("checkouts");
-                    d = otry!(find_git_src_dir(d, kratename, &sha1));
-                    d.push("src");
-                    d.push("lib.rs");
-                    return Some(d);
+                    if Some("registry") == source.split("+").nth(0) {
+                        return get_versioned_cratefile(name, &version);
+                    } else if Some("git") == source.split("+").nth(0) {
+                        let sha1 = otry!(source.split("#").last());
+                        let mut d = otry!(get_cargo_rootdir());
+                        d.push("git");
+                        d.push("checkouts");
+                        d = otry!(find_git_src_dir(d, name, &sha1));
+                        d.push("src");
+                        d.push("lib.rs");
+                        return Some(d);
+                    }
                 }
             }
         }

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -87,8 +87,29 @@ fn get_versioned_cratefile(kratename: &str, version: &str) -> Option<PathBuf> {
     d.push("registry");
     d.push("src");
     d = otry!(find_cratesio_src_dir(d));
-    d.push(kratename.to_string() + "-" + &version);
+
+    // if version=* then search for the first matching folder
+    if version == "*" {
+        use std::fs::read_dir;
+        let mut start_path = d.clone();
+        start_path.push(kratename);
+        let start_name = start_path.to_str().unwrap();
+
+        if let Ok(reader) = read_dir(d) {
+            if let Some(path) = reader
+                                .map(|entry| entry.unwrap().path())
+                                .find(|path| path.to_str().unwrap().starts_with(start_name)) {
+                d = path.clone();                        
+            } else {
+                return None;
+            }
+        } else { return None; }
+    } else {
+        d.push(kratename.to_string() + "-" + &version);
+    }
+    
     d.push("src");
+    debug!("crate path {:?}",d);
 
     // First, check for package name at root (src/kratename/lib.rs)
     d.push(kratename.to_string());
@@ -118,7 +139,17 @@ fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
         _ => return None
     };
 
-    match t.get(kratename) {
+    let mut name = kratename;
+    let value = if kratename.contains('_') {
+        t.iter().find(|&(k, _)| k.replace("-", "_") == name).map(|(k,v)| {
+            name = k;
+            v
+        })
+    } else {
+        t.get(kratename)
+    };
+
+    match value {
         Some(&toml::Value::Table(ref t)) => {
             // local directory
             let relative_path = otry!(getstr(t, "path"));
@@ -129,7 +160,7 @@ fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
         },
         Some(&toml::Value::String(ref version)) => {
             // versioned crate
-            return get_versioned_cratefile(kratename, version);
+            return get_versioned_cratefile(name, version);
         }
         _ => return None
     }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -477,7 +477,7 @@ pub fn search_next_scope(mut startpoint: usize, pathseg: &racer::PathSegment,
 }
 
 pub fn get_crate_file(name: &str, from_path: &Path) -> Option<PathBuf> {
-    debug!("get_create_file {}", name);
+    debug!("get_crate_file {}", name);
     if let Some(p) = cargo::get_crate_file(name, from_path) {
         return Some(p);
     }


### PR DESCRIPTION
close #226

I have fixed the case where the crate is searched in Cargo.lock file, I haven't tried for Cargo.toml `find_src_via_tomlfile` as I didn't have crate examples to test.

I tested on the xsv project which uses rustc-serialize.

Again I couldn't do a simple test.