### PR TITLE
Fix searching enum definition in match arm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,10 +24,11 @@ dependencies = [
 
 [[package]]
 name = "kernel32-sys"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -70,17 +71,17 @@ dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "term"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -98,9 +99,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -59,13 +59,9 @@ fn find_src_via_lockfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
 
 fn get_cargo_rootdir() -> Option<PathBuf> {
     let mut d = otry!(env::home_dir());
-    d.push(".cargo");
-    if path_exists(&d) {
-        return Some(d);
-    }
-
-    // try multirust
-    d.pop();
+    
+    // try multirust first, since people with multirust installed will often still 
+    // have an old .cargo directory lying around
     d.push(".multirust");
     d.push("default");
     if let Ok(mut multirustdefault) = File::open(&d) {
@@ -76,6 +72,13 @@ fn get_cargo_rootdir() -> Option<PathBuf> {
         d.push(s.trim());
         d.push("cargo");
         debug!("get_cargo_rootdir root is {:?}",d);
+        return Some(d)
+    }
+
+    d.pop();
+    d.pop();
+    d.push(".cargo");
+    if path_exists(&d) {
         Some(d)
     } else {
         None

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -180,34 +180,19 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: &str, searchstr: 
             let matchstart = stmtstart + n;
             let matchstmt = typeinf::get_first_stmt(&msrc[matchstart..]);
             // The definition could be in the match LHS arms. Try to find this
-            debug!("PHIL found a match statement, examining match arms (len {}) |{}|",
-                   matchstmt.len(), matchstmt);
-
-            let masked_matchstmt = mask_matchstmt(matchstmt, scopestart+1 - matchstart);
-            debug!("PHIL masked match stmt is len {} |{}|", masked_matchstmt.len(), masked_matchstmt);
+            let masked_matchstmt = mask_matchstmt(matchstmt, scopestart + 1 - matchstart);
+            debug!("found match stmt, masked is len {} |{}|", masked_matchstmt.len(), masked_matchstmt);
 
             // Locate the match arm LHS by finding the => just before point and then backtracking
-            let mut rhs = &*masked_matchstmt;
-            let mut arm = 0;
-            while let Some(n) = rhs.find("=>") {
-                debug!("PHIL match arm n is {}, {}, {}, {}", arm, n, matchstart, point);
-                if arm + n + matchstart > point {
-                    break;
-                } else {
-                    arm += n + 2;
-                    rhs = &rhs[n+2..];
-                }
-            }
-            debug!("PHIL matched arm rhs is |{}|", &masked_matchstmt[arm-2..]);
+            let arm = masked_matchstmt[..point-matchstart].rfind("=>").unwrap_or(0);
+            debug!("PHIL matched arm rhs is |{}|", &masked_matchstmt[arm..]);
 
-            let lhs_start = scopes::get_start_of_pattern(msrc, matchstart + arm -2);
-            let lhs = &msrc[lhs_start..matchstart + arm - 2];
+            let lhs_start = scopes::get_start_of_pattern(msrc, matchstart + arm);
+            let lhs = &msrc[lhs_start..matchstart + arm];
 
-            // Now create a pretend match expression with just the one match arm in it
-            let mut fauxmatchstmt = (&msrc[matchstart..scopestart]).to_string();
-            fauxmatchstmt = fauxmatchstmt + "{";
-            let faux_prefix_size = fauxmatchstmt.len();
-            fauxmatchstmt = fauxmatchstmt + lhs + " => () };";
+            // Now create a pretend match expression with just the one match arm in it            
+            let faux_prefix_size = scopestart - matchstart + 1;
+            let fauxmatchstmt = format!("{}{{{} => () }};", &msrc[matchstart..scopestart], lhs);
 
             debug!("PHIL arm lhs is |{}|", lhs);
             debug!("PHIL arm fauxmatchstmt is |{}|, {}", fauxmatchstmt, faux_prefix_size);

--- a/src/racer/test.rs
+++ b/src/racer/test.rs
@@ -1087,6 +1087,25 @@ fn finds_match_arm_var_in_scope() {
 }
 
 #[test]
+fn finds_match_arm_enum() {
+    let src="
+    enum MyEnum {
+        Foo,
+        Bar
+    }
+    match foo {
+       MyEnum::Foo => 1,
+       MyEnum::Bar => 2
+    ";
+    let path = tmpname();
+    write_file(&path, src);
+    let pos = scopes::coords_to_point(src, 7, 18);
+    let got = find_definition(src, &path, pos).unwrap();
+    fs::remove_file(&path).unwrap();
+    assert_eq!("Foo", got.matchstr);
+}
+
+#[test]
 fn finds_match_arm_var_with_nested_match() {
     let src="
     match foo {


### PR DESCRIPTION
When testing #273, I encountered an issue in `search_scope_headers`.
We can early return in case we are in the enum part of the match arm.

Added a test which doesn't work on current master