### PR TITLE
Further elisp fixes

### DIFF
--- a/editors/emacs/Cask
+++ b/editors/emacs/Cask
@@ -2,3 +2,6 @@
 (source melpa)
 
 (package-file "racer.el")
+
+(depends-on "rust-mode")
+(depends-on "company")

--- a/editors/emacs/racer.el
+++ b/editors/emacs/racer.el
@@ -1,4 +1,4 @@
-;;; racer.el --- Rust completion via racer
+;;; racer.el --- Rust completion via racer with company
 
 ;; Copyright (c) 2014 Phil Dawes
 

--- a/editors/emacs/racer.el
+++ b/editors/emacs/racer.el
@@ -153,10 +153,10 @@
 
           (when (string-match "^PREFIX \\(.+\\),\\(.+\\),\\(.*\\)$" line)
             (setq racer-start-pos (string-to-number (match-string 1 line)))
-            (setq racer-end-pos (string-to-number (match-string 2 line))))))
-      (list (- (point) (- racer-end-pos racer-start-pos))
-            (point)
-            racer-completion-results))))
+            (setq racer-end-pos (string-to-number (match-string 2 line)))))
+        (list (- (point) (- racer-end-pos racer-start-pos))
+              (point)
+              racer-completion-results)))))
 
 (defun racer-company-complete (command &optional arg &rest ignored)
   "Run the racer command for `COMMAND' and format using `ARG'.


### PR DESCRIPTION
Hi Phil

A few additional improvements to racer.el.

1. Fix a crash in `racer--complete-at-point-fn`. I introduced this in my last PR and didn't notice because it doesn't crash if you had loaded the old racer.el in your current emacs session. Sorry about that.
2. Improve package description, as suggested by the MELPA team.
3. Minor corrections to the cask file.