### PR TITLE
Ignore file which cannot be open

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -367,7 +367,7 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
                         }
                         {
                             // try just <name>.rs
-                            if fname.ends_with(".rs") {
+                            if fname.ends_with(".rs") && File::open(&fpath_buf).is_ok() {
                                 let m = Match {
                                                matchstr: (&fname[..(fname.len()-3)]).to_string(),
                                                filepath: fpath_buf.clone(),

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -347,46 +347,9 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
                     }
 
                     if fname.starts_with(searchstr) {
-                        {
-                            // try <name>/<name>.rs, like in the servo codebase
-                            let filepath = fpath_buf.deref().join(format!("{}.rs", fname));
+                        for name in &[&format!("{}.rs", fname)[..], "mod.rs", "lib.rs"] {
+                            let filepath = fpath_buf.deref().join(name);
 
-                            if File::open(&filepath).is_ok() {
-                                let m = Match {
-                                               matchstr: fname.to_string(),
-                                               filepath: filepath.to_path_buf(),
-                                               point: 0,
-                                               local: false,
-                                               mtype: Module,
-                                               contextstr: filepath.to_str().unwrap().to_string(),
-                                               generic_args: Vec::new(),
-                                               generic_types: Vec::new(),
-                                               session: core::Session::from_path(&filepath, &filepath)
-                                };
-                                out.push(m);
-                            }
-                        }
-                        {
-                            // try <name>/mod.rs
-                            let filepath = fpath_buf.deref().join("mod.rs");
-                            if File::open(&filepath).is_ok() {
-                                let m = Match {
-                                               matchstr: fname.to_string(),
-                                               filepath: filepath.to_path_buf(),
-                                               point: 0,
-                                               local: false,
-                                               mtype: Module,
-                                               contextstr: filepath.to_str().unwrap().to_string(),
-                                               generic_args: Vec::new(),
-                                               generic_types: Vec::new(),
-                                               session: core::Session::from_path(&filepath, &filepath)
-                                };
-                                out.push(m);
-                            }
-                        }
-                        {
-                            // try <name>/lib.rs
-                            let filepath = Path::new(srcpath).join("lib.rs");
                             if File::open(&filepath).is_ok() {
                                 let m = Match {
                                                matchstr: fname.to_string(),


### PR DESCRIPTION
We read files returned by do_file_search and as directory may contain
files which cannot be opened this commit remove them from the result.

Emacs may create a lock file when a buffer is modified and not saved:
http://www.gnu.org/software/emacs/manual/html_node/emacs/Interlocking.html
as this file cannot be read it make racer panics when trying to read the file.

Note: I wanted to add a unit test but i do not know how i could create an invalid file.