### PR TITLE
Use the tag ring before jumping to a definition.

### DIFF
--- a/editors/emacs/racer.el
+++ b/editors/emacs/racer.el
@@ -59,6 +59,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'etags)
 (require 'company)
 (require 'rust-mode)
 
@@ -201,7 +202,7 @@
   (let ((racer-tmp-file-name (concat (buffer-file-name) ".racertmp")))
     (racer--write-tmp-file racer-tmp-file-name)
     (setenv "RUST_SRC_PATH" (expand-file-name racer-rust-src-path))
-    (push-mark)
+    (ring-insert find-tag-marker-ring (point-marker))
     (let ((lines (process-lines racer-cmd
                                 "find-definition"
                                 (number-to-string (racer-get-line-number))


### PR DESCRIPTION
Hi Phil

I've made a change to `racer-find-definition` so that it just works with `M-,` (which is `pop-tag-mark`). This is consistent with other emacs tools that jump to a definition (tags, slime-nav). What do you think?