### PR TITLE
Changed Vundle to Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
   Vundle users:
   ```
-  Vundle 'phildawes/racer'
+  Plugin 'phildawes/racer'
   ```
 
   NeoBundle users:


### PR DESCRIPTION
Small update.

Vundle changed a few versions ago the word `Vundle` to `Plugin`