### PR TITLE
Handle win32 search path separator & add win32 src path

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -12,7 +12,8 @@
 if !exists('g:racer_cmd')
     let path = escape(expand('<sfile>:p:h'), '\') . '/../target/release/'
     if isdirectory(path)
-        let $PATH .= ':' . path
+        let s:pathsep = has("win32") ? ';' : ':'
+        let $PATH .= s:pathsep . path
     endif
     let g:racer_cmd = 'racer'
 
@@ -28,6 +29,9 @@ if !exists('$RUST_SRC_PATH')
     endif
     if isdirectory("/usr/src/rust/src")
         let $RUST_SRC_PATH="/usr/src/rust/src"
+    endif
+    if isdirectory("C:\\rust\\src")
+        let $RUST_SRC_PATH="C:\\rust\\src"
     endif
 endif
 if !isdirectory($RUST_SRC_PATH)


### PR DESCRIPTION
When new defaults for `g:racer_cmd` and `$RUST_SRC_PATH` were added to the Vim plugin recently, the code assumed a colon as the path separator -- which is fine on all sane OS's. Alas, on Windows the separator is a semicolon. This left the $PATH variable broken if g:racer_cmd was not set when loading racer. This change detects `has("win32")` and does the right thing.

Also, added a reasonable default for the RUST_SRC_PATH on Windows while I was at it.