### PR TITLE
Emacs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,33 +29,35 @@
 
 2. Allow Emacs to install packages from MELPA:
 
-   ```
+   ```el
    (require 'package)
    (add-to-list 'package-archives '("melpa" . "http://melpa.milkbox.net/packages/"))
    ```
 
-2. Install racer: ```M-x package-list``` Find the racer package and install it
+2. Install racer: `M-x package-list` Find the racer package and install it
 
 3. If racer is not in the path, configure emacs to find your racer binary and rust source directory
-   ```
+   ```el
    (setq racer-cmd "<path-to-racer-srcdir>/target/release/racer")
    (setq racer-rust-src-path "<path-to-rust-srcdir>/src/")
    ```
 
-4. Configure Emacs to activate racer and setup some key bindings when rust-mode starts:
-
-   ```
-   (add-hook 'rust-mode-hook 
-	  '(lambda () 
-	     (racer-activate)
-	     (racer-turn-on-eldoc)
-	     (local-set-key (kbd "M-.") #'racer-find-definition)
-	     (local-set-key (kbd "TAB") #'racer-complete-or-indent)))
+4. Configure Emacs to activate racer when rust-mode starts:
+   ```el
+   (add-hook 'rust-mode-hook #'racer-mode)
+   (add-hook 'racer-mode-hook #'eldoc-mode)
    ```
 
-5. Open a rust file and try typing ```use std::io::B``` and press \<tab\>
+   For completions, install company with `M-x package-install RET company`. A sample configuration:
+   ```el
+   (global-set-key (kbd "TAB") #'company-complete) ; or company-indent-or-complete-common
+   (setq company-tooltip-align-annotations t)
+   ```
+   For automatic completions, customize `company-idle-delay` and `company-minimum-prefix-length`.
 
-6. Place your cursor over a symbol and hit M-. to jump to the
+5. Open a rust file and try typing ```use std::io::B``` and press `<tab>`
+
+6. Place your cursor over a symbol and hit `M-.` to jump to the
 definition.
 
 ## Vim integration

--- a/editors/emacs/Cask
+++ b/editors/emacs/Cask
@@ -6,3 +6,4 @@
 (depends-on "rust-mode")
 (depends-on "company")
 (depends-on "dash")
+(depends-on "s")

--- a/editors/emacs/racer.el
+++ b/editors/emacs/racer.el
@@ -1,4 +1,4 @@
-;;; racer.el --- Rust completion via racer with company
+;;; racer.el --- Rust completion and code navigation via racer
 
 ;; Copyright (c) 2014 Phil Dawes
 
@@ -41,25 +41,17 @@
 ;; (setq racer-rust-src-path "<path-to-rust-srcdir>/src/")
 ;; (setq racer-cmd "<path-to-racer>/target/release/racer")
 ;;
-;; To set up racer for completion in Rust buffers, add it
-;; `rust-mode-hook':
+;; To activate racer in Rust buffers, run:
 ;;
-;; (add-hook 'rust-mode-hook #'racer-activate)
+;; (add-hook 'rust-mode-hook #'racer-mode)
 ;;
-;; To use TAB for both indent and completion in Rust:
-;;
-;; (require 'rust-mode)
-;; (define-key rust-mode-map (kbd "TAB") #'racer-complete-or-indent)
-;;
-;; You can also use racer to find definitions. To bind this to a key:
-;;
-;; (require 'rust-mode)
-;; (define-key rust-mode-map (kbd "M-.") #'racer-find-definition)
+;; You can also use racer to find definition at point via
+;; `racer-find-definition', bound to `M-.' by default.
 ;;
 ;; Finally, you can also use Racer to show the signature of the
 ;; current function in the minibuffer:
 ;;
-;; (add-hook 'rust-mode-hook #'racer-turn-on-eldoc)
+;; (add-hook 'racer-mode-hook #'eldoc-mode)
 
 ;;; Code:
 

--- a/editors/emacs/racer.el
+++ b/editors/emacs/racer.el
@@ -232,7 +232,7 @@ foo(bar, |baz); -> foo|(bar, baz);"
         ;; foo|(bar, baz);
         (goto-char start-pos)))))
 
-(defun racer--eldoc ()
+(defun racer-eldoc ()
   "Show eldoc for context at point."
   (save-excursion
     (racer--goto-func-name)
@@ -249,18 +249,16 @@ foo(bar, |baz); -> foo|(bar, baz);"
        ;; Finally, apply syntax highlighting for the minibuffer.
        (racer--syntax-highlight)))))
 
-;;;###autoload
-(defun racer-turn-on-eldoc ()
-  "Enable eldoc using Racer."
-  (make-local-variable 'eldoc-documentation-function)
-  (setq-local eldoc-documentation-function #'racer--eldoc)
-  (eldoc-mode))
+(defvar racer-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "M-.") #'racer-find-definition)
+    map))
 
-;;;###autoload
-(defun racer-turn-off-eldoc ()
-  "Disable eldoc using Racer."
-  (kill-local-variable 'eldoc-documentation-function)
-  (eldoc-mode -1))
+(define-minor-mode racer-mode
+  "Minor mode for racer."
+  :lighter " racer"
+  :keymap racer-mode-map
+  (setq-local eldoc-documentation-function #'racer-eldoc))
 
 (provide 'racer)
 ;;; racer.el ends here

--- a/editors/emacs/racer.el
+++ b/editors/emacs/racer.el
@@ -206,5 +206,8 @@ foo(bar, |baz); -> foo|(bar, baz);"
   (make-local-variable 'completion-at-point-functions)
   (add-to-list 'completion-at-point-functions #'racer-complete-at-point))
 
+(define-obsolete-function-alias 'racer-turn-on-eldoc 'eldoc-mode)
+(define-obsolete-function-alias 'racer-activate 'racer-mode)
+
 (provide 'racer)
 ;;; racer.el ends here

--- a/editors/emacs/racer.el
+++ b/editors/emacs/racer.el
@@ -148,7 +148,10 @@
                              (racer--call-at-point "find-definition")))
     (-let [(_name line col file _matchtype _ctx)
            (s-split-up-to "," (s-chop-prefix "MATCH " match) 5)]
-      (ring-insert find-tag-marker-ring (point-marker))
+      (if (fboundp 'xref-push-marker-stack)
+          (xref-push-marker-stack)
+        (with-no-warnings
+          (ring-insert find-tag-marker-ring (point-marker))))
       (find-file file)
       (goto-char (point-min))
       (forward-line (1- (string-to-number line)))
@@ -159,7 +162,10 @@
   (with-temp-buffer
     (insert str)
     (delay-mode-hooks (rust-mode))
-    (font-lock-fontify-buffer)
+    (if (fboundp 'font-lock-ensure)
+        (font-lock-ensure)
+      (with-no-warnings
+        (font-lock-fontify-buffer)))
     (buffer-string)))
 
 (defun racer--goto-func-name ()


### PR DESCRIPTION
I ended up doing quite a lot of changes, see commits for more details.

Setting up `racer-mode` should be more straightforward now:
```el
(add-hook 'rust-mode-hook #'racer-mode)
(add-hook 'racer-mode-hook #'eldoc-mode)
(setq company-tooltip-align-annotations t) ; looks better
```
I also removed the dependency of company since completion-at-point is supported out of the box via `company-capf`.
Fixes #339.

Cheers :)