### PR TITLE
[RFC] Clippy lint fixes

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -83,12 +83,12 @@ fn complete(match_found: &Fn(Match), args: &[String]) {
             let fpath = Path::new(fname);
             let session = core::Session::from_path(&fpath, &substitute_file);
             let src = core::load_file(&fpath, &session);
-            let line = &*getline(&substitute_file, linenum, &session);
+            let line = &getline(&substitute_file, linenum, &session);
             let (start, pos) = util::expand_ident(line, charnum);
             println!("PREFIX {},{},{}", start, pos, &line[start..pos]);
 
-            let point = scopes::coords_to_point(&*src, linenum, charnum);
-            for m in core::complete_from_file(&*src, &fpath, point, &session) {
+            let point = scopes::coords_to_point(&src, linenum, charnum);
+            for m in core::complete_from_file(&src, &fpath, point, &session) {
                 match_found(m);
             }
             println!("END");
@@ -131,7 +131,7 @@ fn prefix(args: &[String]) {
 
     // print the start, end, and the identifier prefix being matched
     let path = Path::new(fname);
-    let line = &*getline(&path, linenum, &session);
+    let line = &getline(&path, linenum, &session);
     let (start, pos) = util::expand_ident(line, charnum);
     println!("PREFIX {},{},{}", start, pos, &line[start..pos]);
 }
@@ -153,9 +153,9 @@ fn find_definition(args: &[String]) {
     let fpath = Path::new(&fname);
     let session = core::Session::from_path(&fpath, &substitute_file);
     let src = core::load_file(&fpath, &session);
-    let pos = scopes::coords_to_point(&*src, linenum, charnum);
+    let pos = scopes::coords_to_point(&src, linenum, charnum);
 
-    core::find_definition(&*src, &fpath, pos, &session).map(match_fn);
+    core::find_definition(&src, &fpath, pos, &session).map(match_fn);
     println!("END");
 }
 

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -27,8 +27,7 @@ pub fn with_error_checking_parse<F, T>(s: String, f: F) -> Option<T> where F: Fn
         Some(p) => p,
         None => return None
     };
-    let x = f(&mut p);
-    x
+    f(&mut p)
 }
 
 // parse a string, return a stmt
@@ -263,7 +262,7 @@ impl<'v> visit::Visitor<'v> for LetTypeVisitor {
             v.visit_expr(&**expr);
             self.result = v.result.and_then(|ty|
                    destructure_pattern_to_ty(&**pattern, self.pos, &ty, &self.scope))
-                .and_then(|ty| path_to_match(ty));
+                .and_then(path_to_match);
         } else {
             visit::walk_expr(self, ex)
         }
@@ -288,7 +287,7 @@ impl<'v> visit::Visitor<'v> for LetTypeVisitor {
         debug!("LetTypeVisitor: ty is {:?}. pos is {}, src is |{}|", ty, self.pos, self.srctxt);
         self.result = ty.and_then(|ty|
            destructure_pattern_to_ty(&*local.pat, self.pos, &ty, &self.scope))
-            .and_then(|ty| path_to_match(ty));
+            .and_then(path_to_match);
     }
 }
 
@@ -314,7 +313,7 @@ impl<'v> visit::Visitor<'v> for MatchTypeVisitor {
                         debug!("PHIL point is in pattern |{:?}|", pattern);
                         self.result = v.result.as_ref().and_then(|ty|
                                destructure_pattern_to_ty(&**pattern, self.pos, ty, &self.scope))
-                            .and_then(|ty| path_to_match(ty));
+                            .and_then(path_to_match);
                     }
                 }
             }
@@ -982,7 +981,7 @@ impl<'v> visit::Visitor<'v> for FnArgTypeVisitor {
                 self.result = to_racer_ty(&*arg.ty, &self.scope)
                     .and_then(|ty| destructure_pattern_to_ty(&*arg.pat, self.argpos,
                                                    &ty, &self.scope))
-                    .and_then(|ty| path_to_match(ty));
+                    .and_then(path_to_match);
                 break;
             }
         }

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -14,7 +14,7 @@ use syntex_syntax::ptr::P;
 use syntex_syntax::visit::{self, Visitor};
 
 // This code ripped from libsyntax::util::parser_testing
-pub fn string_to_parser<'a>(ps: &'a ParseSess, source_str: String) -> Option<Parser<'a>> {
+pub fn string_to_parser(ps: &ParseSess, source_str: String) -> Option<Parser> {
     let fm = ps.codemap().new_filemap("bogofile".to_string(), source_str);
     let srdr = lexer::StringReader::new(&ps.span_diagnostic, fm);
     let p = Parser::new(ps, Vec::new(), Box::new(srdr));

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -74,7 +74,7 @@ impl<'v> visit::Visitor<'v> for UseVisitor {
                 },
                 ast::ViewPathList(ref pth, ref paths) => {
                     let basepath = to_racer_path(pth);
-                    for path in paths.iter() {
+                    for path in paths {
                         match path.node {
                             ast::PathListIdent{name, ..} => {
                                 let name = name.name.to_string();
@@ -154,7 +154,7 @@ fn to_racer_ty(ty: &ast::Ty, scope: &Scope) -> Option<Ty> {
     return match ty.node {
         ast::TyTup(ref items) => {
             let mut res = Vec::new();
-            for t in items.iter() {
+            for t in items {
                 res.push(match to_racer_ty(&**t, scope) {
                     Some(t) => t,
                     None => return None
@@ -198,7 +198,7 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
                 TyTuple(ref typeelems) => {
                     let mut i = 0usize;
                     let mut res = None;
-                    for p in tuple_elements.iter() {
+                    for p in tuple_elements {
                         if point_is_in_span(point as u32, &p.span) {
                             let ref ty = typeelems[i];
                             res = destructure_pattern_to_ty(&**p, point, ty, scope);
@@ -219,7 +219,7 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
             let contextty = path_to_match(ty.clone());
             if let (Some(m), Some(children)) = (m, children.as_ref()) {
                 let mut res = None;
-                for p in children.iter() {
+                for p in children {
                     if point_is_in_span(point as u32, &p.span) {
 
                         res = typeinf::get_tuplestruct_field_type(i, &m)
@@ -307,8 +307,8 @@ impl<'v> visit::Visitor<'v> for MatchTypeVisitor {
 
             debug!("PHIL sub type is {:?}", v.result);
 
-            for arm in arms.iter() {
-                for pattern in arm.pats.iter() {
+            for arm in arms {
+                for pattern in &arm.pats {
                     if point_is_in_span(self.pos as u32, &pattern.span) {
                         debug!("PHIL point is in pattern |{:?}|", pattern);
                         self.result = v.result.as_ref().and_then(|ty|
@@ -329,10 +329,10 @@ fn resolve_ast_path(path: &ast::Path, filepath: &Path, pos: usize, session: &cor
 
 fn to_racer_path(pth: &ast::Path) -> core::Path {
     let mut v = Vec::new();
-    for seg in pth.segments.iter() {
+    for seg in &pth.segments {
         let name = seg.identifier.name.to_string();
         let mut types = Vec::new();
-        for ty in seg.parameters.types().iter() {
+        for ty in seg.parameters.types() {
             if let ast::TyPath(_, ref path) = ty.node {
                 types.push(to_racer_path(path));
             }
@@ -508,7 +508,7 @@ impl<'v> visit::Visitor<'v> for ExprTypeVisitor {
 
             ast::ExprTup(ref exprs) => {
                 let mut v = Vec::new();
-                for expr in exprs.iter() {
+                for expr in exprs {
                     self.visit_expr(&**expr);
                     match self.result {
                         Some(ref t) => v.push(t.clone()),
@@ -603,7 +603,7 @@ struct StructVisitor {
 
 impl<'v> visit::Visitor<'v> for StructVisitor {
     fn visit_struct_def(&mut self, struct_definition: &ast::StructDef, _: ast::Ident, _: &ast::Generics, _: ast::NodeId) {
-        for field in struct_definition.fields.iter() {
+        for field in &struct_definition.fields {
             let codemap::BytePos(point) = field.span.lo;
 
             match field.node.kind {
@@ -774,7 +774,7 @@ impl<'v> visit::Visitor<'v> for EnumVisitor {
             let codemap::BytePos(point2) = i.span.hi;
             debug!("name point is {} {}", point, point2);
 
-            for variant in enum_definition.variants.iter() {
+            for variant in &enum_definition.variants {
                 let codemap::BytePos(point) = variant.span.lo;
                 self.values.push(((&variant.node.name).to_string(), point as usize));
             }
@@ -967,7 +967,7 @@ pub struct FnArgTypeVisitor {
 
 impl<'v> visit::Visitor<'v> for FnArgTypeVisitor {
     fn visit_fn(&mut self, _: visit::FnKind, fd: &ast::FnDecl, _: &ast::Block, _: codemap::Span, _: ast::NodeId) {
-        for arg in fd.inputs.iter() {
+        for arg in &fd.inputs {
             let codemap::BytePos(lo) = arg.pat.span.lo;
             let codemap::BytePos(hi) = arg.pat.span.hi;
             if self.argpos >= (lo as usize) && self.argpos <= (hi as usize) {

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -629,32 +629,29 @@ pub struct TypeVisitor {
 
 impl<'v> visit::Visitor<'v> for TypeVisitor {
     fn visit_item(&mut self, item: &ast::Item) {
-        match item.node {
-            ast::ItemTy(ref ty, _) => {
-                self.name = Some(item.ident.name.to_string());
+        if let ast::ItemTy(ref ty, _) = item.node {
+            self.name = Some(item.ident.name.to_string());
 
-                let typepath = match ty.node {
-                    ast::TyRptr(_, ref ty) => {
-                        match ty.ty.node {
-                            ast::TyPath(_, ref path) => {
-                                let type_ = to_racer_path(path);
-                                debug!("type type is {:?}", type_);
-                                Some(type_)
-                            }
-                            _ => None
+            let typepath = match ty.node {
+                ast::TyRptr(_, ref ty) => {
+                    match ty.ty.node {
+                        ast::TyPath(_, ref path) => {
+                            let type_ = to_racer_path(path);
+                            debug!("type type is {:?}", type_);
+                            Some(type_)
                         }
+                        _ => None
                     }
-                    ast::TyPath(_, ref path) => {
-                        let type_ = to_racer_path(path);
-                        debug!("type type is {:?}", type_);
-                        Some(type_)
-                    }
-                    _ => None
-                };
-                self.type_ = typepath;
-                debug!("typevisitor type is {:?}", self.type_);
-            }
-            _ => ()
+                }
+                ast::TyPath(_, ref path) => {
+                    let type_ = to_racer_path(path);
+                    debug!("type type is {:?}", type_);
+                    Some(type_)
+                }
+                _ => None
+            };
+            self.type_ = typepath;
+            debug!("typevisitor type is {:?}", self.type_);
         }
     }
 }
@@ -665,11 +662,8 @@ pub struct TraitVisitor {
 
 impl<'v> visit::Visitor<'v> for TraitVisitor {
     fn visit_item(&mut self, item: &ast::Item) {
-        match item.node {
-            ast::ItemTrait(_, _, _, _) => {
-                self.name = Some(item.ident.name.to_string());
-            }
-            _ => ()
+        if let ast::ItemTrait(_, _, _, _) = item.node {
+            self.name = Some(item.ident.name.to_string());
         }
     }
 }

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -151,7 +151,7 @@ impl<'v> visit::Visitor<'v> for PatVisitor {
 }
 
 fn to_racer_ty(ty: &ast::Ty, scope: &Scope) -> Option<Ty> {
-    return match ty.node {
+    match ty.node {
         ast::TyTup(ref items) => {
             let mut res = Vec::new();
             for t in items {
@@ -188,13 +188,13 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
         ast::PatIdent(_ , ref spannedident, _) => {
             if point_is_in_span(point as u32, &spannedident.span) {
                 debug!("destructure_pattern_to_ty matched an ident!");
-                return Some(ty.clone());
+                Some(ty.clone())
             } else {
                 panic!("Expecting the point to be in the patident span. pt: {}", point);
             }
         }
         ast::PatTup(ref tuple_elements) => {
-            return match *ty {
+            match *ty {
                 TyTuple(ref typeelems) => {
                     let mut i = 0usize;
                     let mut res = None;
@@ -361,7 +361,7 @@ fn find_type_match(path: &core::Path, fpath: &Path, pos: usize, session: &core::
                    }
                });
 
-    return res.and_then(|m| {
+    res.and_then(|m| {
         // add generic types to match (if any)
         let types: Vec<core::PathSearch> = path.generic_types()
             .map(|typepath|
@@ -373,11 +373,11 @@ fn find_type_match(path: &core::Path, fpath: &Path, pos: usize, session: &core::
                  }).collect();
 
         if types.is_empty() {
-            return Some(TyMatch(m));
+            Some(TyMatch(m))
         } else {
-            return Some(TyMatch(m.with_generic_types(types.clone())));
+            Some(TyMatch(m.with_generic_types(types.clone())))
         }
-    });
+    })
 }
 
 fn get_type_of_typedef(m: Match) -> Option<Match> {
@@ -387,15 +387,15 @@ fn get_type_of_typedef(m: Match) -> Option<Match> {
     let blobstart = m.point - 5;  // - 5 because 'type '
     let blob = &msrc[blobstart..];
 
-    return codeiter::iter_stmts(blob).nth(0).and_then(|(start, end)| {
+    codeiter::iter_stmts(blob).nth(0).and_then(|(start, end)| {
         let blob = msrc[blobstart + start..blobstart+end].to_owned();
         debug!("get_type_of_typedef blob string {}", blob);
         let res = parse_type(blob);
         debug!("get_type_of_typedef parsed type {:?}", res.type_);
-        return res.type_;
+        res.type_
     }).and_then(|type_| {
         nameres::resolve_path_with_str(&type_, &m.filepath, m.point, core::SearchType::ExactMatch, core::Namespace::TypeNamespace, &m.session).nth(0)
-    });
+    })
 }
 
 
@@ -535,7 +535,7 @@ impl<'v> visit::Visitor<'v> for ExprTypeVisitor {
 // gets generics info from the context match
 fn path_to_match_including_generics(ty: Ty, contextm: &core::Match) -> Option<Ty> {
     assert_eq!(&contextm.filepath, &contextm.session.query_path);
-    return match ty {
+    match ty {
         TyPathSearch(ref fieldtypepath, ref scope) => {
 
             if fieldtypepath.segments.len() == 1 {
@@ -557,7 +557,7 @@ fn path_to_match_including_generics(ty: Ty, contextm: &core::Match) -> Option<Ty
             find_type_match(fieldtypepath, &scope.filepath, scope.point, &scope.session)
         }
         _ => Some(ty)
-    };
+    }
 }
 
 

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -194,8 +194,8 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
             }
         }
         ast::PatTup(ref tuple_elements) => {
-            return match ty {
-                &TyTuple(ref typeelems) => {
+            return match *ty {
+                TyTuple(ref typeelems) => {
                     let mut i = 0usize;
                     let mut res = None;
                     for p in tuple_elements.iter() {
@@ -430,8 +430,8 @@ impl<'v> visit::Visitor<'v> for ExprTypeVisitor {
                 self.visit_expr(&**callee_expression);
 
                 self.result = self.result.as_ref().and_then(|m|
-                    match m {
-                        &TyMatch(ref m) =>  {
+                    match *m {
+                        TyMatch(ref m) =>  {
 
                             match m.mtype {
                                 MatchType::Function => typeinf::get_return_type_of_function(m)
@@ -466,8 +466,8 @@ impl<'v> visit::Visitor<'v> for ExprTypeVisitor {
                 self.visit_expr(&**objexpr);
 
                 self.result = self.result.as_ref().and_then(|contextm| {
-                    match contextm {
-                        &TyMatch(ref contextm) => {
+                    match *contextm {
+                        TyMatch(ref contextm) => {
                             let omethod = nameres::search_for_impl_methods(
                                 &contextm.matchstr,
                                 &methodname,
@@ -492,8 +492,8 @@ impl<'v> visit::Visitor<'v> for ExprTypeVisitor {
                 self.visit_expr(&**subexpression);
                 self.result = self.result.as_ref()
                       .and_then(|structm|
-                                match structm {
-                                    &TyMatch(ref structm) => {
+                                match *structm {
+                                    TyMatch(ref structm) => {
                                 typeinf::get_struct_field_type(&fieldname, structm)
                                 .and_then(|fieldtypepath|
                                           find_type_match_including_generics(&fieldtypepath,
@@ -568,8 +568,8 @@ fn find_type_match_including_generics(fieldtype: &core::Ty,
                                       session: &core::Session) -> Option<Ty>{
     assert_eq!(&structm.filepath, &structm.session.query_path);
     assert_eq!(&filepath, &session.query_path.as_path());
-    let fieldtypepath = match fieldtype {
-        &TyPathSearch(ref path, _) => path,
+    let fieldtypepath = match *fieldtype {
+        TyPathSearch(ref path, _) => path,
         _ => {
             debug!("EXPECTING A PATH!! Cannot handle other types yet. {:?}", fieldtype);
             return None

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -15,7 +15,7 @@ use syntex_syntax::visit::{self, Visitor};
 
 // This code ripped from libsyntax::util::parser_testing
 pub fn string_to_parser(ps: &ParseSess, source_str: String) -> Option<Parser> {
-    let fm = ps.codemap().new_filemap("bogofile".to_string(), source_str);
+    let fm = ps.codemap().new_filemap("bogofile".into(), source_str);
     let srdr = lexer::StringReader::new(&ps.span_diagnostic, fm);
     let p = Parser::new(ps, Vec::new(), Box::new(srdr));
     Some(p)
@@ -388,7 +388,7 @@ fn get_type_of_typedef(m: Match) -> Option<Match> {
     let blob = &msrc[blobstart..];
 
     return codeiter::iter_stmts(blob).nth(0).and_then(|(start, end)| {
-        let blob = msrc[blobstart + start..blobstart+end].to_string();
+        let blob = msrc[blobstart + start..blobstart+end].to_owned();
         debug!("get_type_of_typedef blob string {}", blob);
         let res = parse_type(blob);
         debug!("get_type_of_typedef parsed type {:?}", res.type_);

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -155,14 +155,14 @@ fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> 
                 continue;
             }
         } else {
-            d.push(kratename.to_string() + "-" + &version);
+            d.push(kratename.to_owned() + "-" + &version);
         }
         
         d.push("src");
         debug!("crate path {:?}",d);
 
         // First, check for package name at root (src/kratename/lib.rs)
-        d.push(kratename.to_string());
+        d.push(kratename);
         d.push("lib.rs");
         if let Err(_) = File::open(&d) {
             // It doesn't exist, so assume src/lib.rs

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -178,7 +178,7 @@ fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> 
 
         return Some(d)
     }
-    return None;
+    None
  }
 
 fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
@@ -227,16 +227,16 @@ fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
         Some(&toml::Value::Table(ref t)) => {
             // local directory
             let relative_path = otry!(getstr(t, "path"));
-            return Some(otry!(cargofile.parent())
-                        .join(relative_path)
-                        .join("src")
-                        .join("lib.rs"));
+            Some(otry!(cargofile.parent())
+                 .join(relative_path)
+                 .join("src")
+                 .join("lib.rs"))
         },
         Some(&toml::Value::String(ref version)) => {
             // versioned crate
-            return get_versioned_cratefile(name, version, cargofile);
+            get_versioned_cratefile(name, version, cargofile)
         }
-        _ => return None
+        _ => None
     }
 }
 
@@ -309,10 +309,10 @@ fn find_cargo_tomlfile(currentfile: &Path) -> Option<PathBuf> {
     let mut f = currentfile.to_path_buf();
     f.push("Cargo.toml");
     if path_exists(f.as_path()) {
-        return Some(f);
+        Some(f)
     } else {
         if f.pop() && f.pop() {
-            return find_cargo_tomlfile(&f);
+            find_cargo_tomlfile(&f)
         } else {
             None
         }

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -41,15 +41,14 @@ impl<'a> Iterator for CodeIndicesIter<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<(usize, usize)> {
-        let res = match self.state {
+        match self.state {
             State::StateCode => Some(code(self)),
             State::StateComment => Some(comment(self)),
             State::StateCommentBlock  => Some(comment_block(self)),
             State::StateString => Some(string(self)),
             State::StateChar => Some(char(self)),
             State::StateFinished => None
-        };
-        res
+        }
     }
 }
 

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -59,7 +59,7 @@ fn code(self_: &mut CodeIndicesIter) -> (usize, usize) {
         _ => { self_.pos }
     };
     let src_bytes = self_.src.as_bytes();
-    for &b in src_bytes[self_.pos..].iter() {
+    for &b in &src_bytes[self_.pos..] {
         self_.pos += 1;
         match b {
             b'/' => match src_bytes[self_.pos] {
@@ -99,7 +99,7 @@ fn code(self_: &mut CodeIndicesIter) -> (usize, usize) {
 }
 
 fn comment(self_: &mut CodeIndicesIter) -> (usize, usize) {
-    for &b in self_.src.as_bytes()[self_.pos..].iter() {
+    for &b in &self_.src.as_bytes()[self_.pos..] {
         self_.pos += 1;
         if b == b'\n' { break; }
     }
@@ -109,7 +109,7 @@ fn comment(self_: &mut CodeIndicesIter) -> (usize, usize) {
 fn comment_block(self_: &mut CodeIndicesIter) -> (usize, usize) {
     let mut nesting_level = 0u16; // should be enough
     let mut prev = b' ';
-    for &b in self_.src.as_bytes()[self_.pos..].iter() {
+    for &b in &self_.src.as_bytes()[self_.pos..] {
         self_.pos += 1;
         match b {
             b'/' if prev == b'*' => {
@@ -138,7 +138,7 @@ fn string(self_: &mut CodeIndicesIter) -> (usize, usize) {
         }
     } else {
         let mut is_not_escaped = true;
-        for &b in src_bytes[self_.pos..].iter() {
+        for &b in &src_bytes[self_.pos..] {
             self_.pos += 1;
             match b {
                 b'"' if is_not_escaped  => { break; }, // "
@@ -152,7 +152,7 @@ fn string(self_: &mut CodeIndicesIter) -> (usize, usize) {
 
 fn char(self_: &mut CodeIndicesIter) -> (usize, usize) {
     let mut is_not_escaped = true;
-    for &b in self_.src.as_bytes()[self_.pos..].iter() {
+    for &b in &self_.src.as_bytes()[self_.pos..] {
         self_.pos += 1;
         match b {
             b'\'' if is_not_escaped  => { break; },

--- a/src/racer/codecleaner.rs
+++ b/src/racer/codecleaner.rs
@@ -165,7 +165,7 @@ fn char(self_: &mut CodeIndicesIter) -> (usize, usize) {
 }
 
 /// Returns indices of chunks of code (minus comments and string contents)
-pub fn code_chunks<'a>(src: &'a str) -> CodeIndicesIter<'a> {
+pub fn code_chunks(src: &str) -> CodeIndicesIter {
     CodeIndicesIter { src: src, state: State::StateCode, pos: 0 }
 }
 

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -39,7 +39,7 @@ impl<'a> Iterator for StmtIndicesIter<'a> {
 
             if start == self.pos {
                 // if this is a new stmt block, skip the whitespace
-                for &b in src_bytes[self.pos..self.end].iter() {
+                for &b in &src_bytes[self.pos..self.end] {
                     match b {
                         b' ' | b'\r' | b'\n' | b'\t' => { self.pos += 1; },
                         _ => { break; }
@@ -54,7 +54,7 @@ impl<'a> Iterator for StmtIndicesIter<'a> {
             }
 
             // iterate through the chunk, looking for stmt end
-            for &b in src_bytes[self.pos..self.end].iter() {
+            for &b in &src_bytes[self.pos..self.end] {
                 self.pos += 1;
 
                 match b {

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -107,7 +107,7 @@ fn is_a_use_stmt(src: &str, start: usize, pos: usize) -> bool {
      whitespace.contains(&src_bytes[start+7]))
 }
 
-pub fn iter_stmts<'a>(src: &'a str) -> StmtIndicesIter<'a> {
+pub fn iter_stmts(src: &str) -> StmtIndicesIter {
     StmtIndicesIter{ src: src, it: code_chunks(src), pos: 0, end: 0 }
 }
 

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -146,16 +146,16 @@ impl Path {
 
     pub fn from_vec(global: bool, v: Vec<&str>) -> Path {
         let segs = v
-            .iter()
-            .map(|x| PathSegment{ name:x.to_string(), types: Vec::new() })
+            .into_iter()
+            .map(|x| PathSegment{ name: x.to_owned(), types: Vec::new() })
             .collect::<Vec<_>>();
         Path{ global: global, segments: segs }
     }
 
     pub fn from_svec(global: bool, v: Vec<String>) -> Path {
         let segs = v
-            .iter()
-            .map(|x| PathSegment{ name:x.clone(), types: Vec::new() })
+            .into_iter()
+            .map(|x| PathSegment{ name: x, types: Vec::new() })
             .collect::<Vec<_>>();
         Path{ global: global, segments: segs }
     }
@@ -244,7 +244,7 @@ pub fn load_file(filepath: &path::Path, session: &Session) -> String {
         BufReader::new(f).read_to_end(&mut rawbytes).unwrap();
     } else {
         error!("load_file couldn't open {:?}. Returning empty string",filepath);
-        return "".to_string();
+        return "".into();
     }
 
     // skip BOF bytes, if present
@@ -292,7 +292,7 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize, session:
             }
         },
         CompletionType::CompleteField => {
-            let context = ast::get_type_of(contextstr.to_string(), filepath, pos, session);
+            let context = ast::get_type_of(contextstr.to_owned(), filepath, pos, session);
             debug!("complete_from_file context is {:?}", context);
             context.map(|ty| {
                 if let Ty::TyMatch(m) = ty {
@@ -329,8 +329,8 @@ pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: &
             }
 
             let segs = v
-                .iter()
-                .map(|x| PathSegment{ name: x.to_string(), types: Vec::new() })
+                .into_iter()
+                .map(|x| PathSegment{ name: x.to_owned(), types: Vec::new() })
                 .collect::<Vec<_>>();
             let path = Path{ global: global, segments: segs };
 
@@ -339,7 +339,7 @@ pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: &
                                          session).nth(0);
         },
         CompletionType::CompleteField => {
-            let context = ast::get_type_of(contextstr.to_string(), filepath, pos, session);
+            let context = ast::get_type_of(contextstr.to_owned(), filepath, pos, session);
             debug!("context is {:?}", context);
 
             return context.and_then(|ty| {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -251,9 +251,9 @@ pub fn load_file(filepath: &path::Path, session: &Session) -> String {
     if rawbytes.len() > 2 && rawbytes[0..3] == [0xEF, 0xBB, 0xBF] {
         let mut it = rawbytes.into_iter();
         it.next(); it.next(); it.next();
-        return String::from_utf8(it.collect::<Vec<_>>()).unwrap();
+        String::from_utf8(it.collect::<Vec<_>>()).unwrap()
     } else {
-        return String::from_utf8(rawbytes).unwrap();
+        String::from_utf8(rawbytes).unwrap()
     }
 }
 
@@ -319,7 +319,7 @@ pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: &
 
     debug!("find_definition_ for |{:?}| |{:?}| {:?}", contextstr, searchstr, completetype);
 
-    return match completetype {
+    match completetype {
         CompletionType::CompletePath => {
             let mut v = expr.split("::").collect::<Vec<_>>();
             let mut global = false;
@@ -334,23 +334,23 @@ pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: &
                 .collect::<Vec<_>>();
             let path = Path{ global: global, segments: segs };
 
-            return nameres::resolve_path(&path, filepath, pos,
-                                         SearchType::ExactMatch, Namespace::BothNamespaces,
-                                         session).nth(0);
+            nameres::resolve_path(&path, filepath, pos,
+                                  SearchType::ExactMatch, Namespace::BothNamespaces,
+                                  session).nth(0)
         },
         CompletionType::CompleteField => {
             let context = ast::get_type_of(contextstr.to_owned(), filepath, pos, session);
             debug!("context is {:?}", context);
 
-            return context.and_then(|ty| {
+            context.and_then(|ty| {
                 // for now, just handle matches
                 match ty {
                     Ty::TyMatch(m) => {
-                        return nameres::search_for_field_or_method(m, searchstr, SearchType::ExactMatch).nth(0);
+                        nameres::search_for_field_or_method(m, searchstr, SearchType::ExactMatch).nth(0)
                     }
                     _ => None
                 }
-            });
+            })
         }
     }
 }

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -165,7 +165,7 @@ impl fmt::Debug for Path {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "P["));
         let mut first = true;
-        for seg in self.segments.iter() {
+        for seg in &self.segments {
             if first {
                 try!(write!(f, "{}", seg.name));
                 first = false;
@@ -176,7 +176,7 @@ impl fmt::Debug for Path {
             if !seg.types.is_empty() {
                 try!(write!(f, "<"));
                 let mut tfirst = true;
-                for typath in seg.types.iter() {
+                for typath in &seg.types {
                     if tfirst {
                         try!(write!(f, "{:?}", typath));
                         tfirst = false;

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -295,13 +295,10 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize, session:
             let context = ast::get_type_of(contextstr.to_string(), filepath, pos, session);
             debug!("complete_from_file context is {:?}", context);
             context.map(|ty| {
-                match ty {
-                    Ty::TyMatch(m) => {
-                        for m in nameres::search_for_field_or_method(m, searchstr, SearchType::StartsWith) {
-                            out.push(m)
-                        }
+                if let Ty::TyMatch(m) = ty {
+                    for m in nameres::search_for_field_or_method(m, searchstr, SearchType::StartsWith) {
+                        out.push(m)
                     }
-                    _ => {}
                 }
             });
         }

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -475,8 +475,8 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                 follow_glob &= ALREADY_GLOBBING.with(|c| { c.get().is_none() });
 
                 // don't follow the glob if the path base is the searchstr
-                follow_glob &= !(&*basepath.segments[0].name == searchstr ||
-                    (&*basepath.segments[0].name == "self" && &*basepath.segments[1].name == searchstr));
+                follow_glob &= !(basepath.segments[0].name == searchstr ||
+                    (basepath.segments[0].name == "self" && basepath.segments[1].name == searchstr));
             }
 
             if follow_glob {
@@ -507,7 +507,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
         for path in use_item.paths.into_iter() {
             let len = path.segments.len();
 
-            if symbol_matches(search_type, searchstr, &*ident) { // i.e. 'use foo::bar as searchstr'
+            if symbol_matches(search_type, searchstr, &ident) { // i.e. 'use foo::bar as searchstr'
                 if len == 1 && path.segments[0].name == searchstr {
                     // is an exact match of a single use stmt.
                     // Do nothing because this will be picked up by the module
@@ -522,7 +522,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                         }
                     }
                 }
-            } else if &*ident == "" {   // i.e. no 'as'. e.g. 'use foo::{bar, baz}'
+            } else if ident == "" {   // i.e. no 'as'. e.g. 'use foo::{bar, baz}'
                 // if searching for a symbol and the last path segment 
                 // matches the symbol then find the fqn
                 if len == 1 && path.segments[0].name == searchstr {

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -101,9 +101,9 @@ fn match_pattern_start(src: &str, blobstart: usize, blobend: usize,
     let blob = &src[blobstart..blobend];
     if let Some(start) = find_keyword(blob, pattern, searchstr, search_type, local) {
         if let Some(end) = blob[start..].find(':') {
-            let s = &blob[start..start+end].trim_right();
+            let s = blob[start..start+end].trim_right();
             return Some(Match {
-                matchstr: s.to_string(),
+                matchstr: s.to_owned(),
                 filepath: filepath.to_path_buf(),
                 point: blobstart+start,
                 local: local,
@@ -141,12 +141,12 @@ fn match_pattern_let(msrc: &str, blobstart: usize, blobend: usize,
     let mut out = Vec::new();
     let blob = &msrc[blobstart..blobend];
     if blob.starts_with(pattern) && txt_matches(search_type, searchstr, blob) {
-        let coords = ast::parse_let(blob.to_string());
+        let coords = ast::parse_let(blob.to_owned());
         for &(start, end) in coords.iter() {
             let s = &blob[start..end];
             if symbol_matches(search_type, searchstr, s) {
                 debug!("match_pattern_let point is {}", blobstart + start);
-                out.push(Match { matchstr: s.to_string(),
+                out.push(Match { matchstr: s.to_owned(),
                                    filepath: filepath.to_path_buf(),
                                    point: blobstart + start,
                                    local: local,
@@ -182,7 +182,7 @@ pub fn match_let(msrc: &str, blobstart: usize, blobend: usize,
 }
 
 pub fn first_line(blob: &str) -> String {
-    (&blob[..blob.find('\n').unwrap_or(blob.len())]).to_string()
+    (&blob[..blob.find('\n').unwrap_or(blob.len())]).to_owned()
 }
 
 pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
@@ -209,9 +209,9 @@ pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
             let rawblob = &rawsrc[blobstart..blobend];
             debug!("found an extern crate (unscrubbed): |{}|", rawblob);
 
-            extern_crate = ast::parse_extern_crate(rawblob.to_string());
+            extern_crate = ast::parse_extern_crate(rawblob.to_owned());
         } else {
-            extern_crate = ast::parse_extern_crate(blob.to_string());
+            extern_crate = ast::parse_extern_crate(blob.to_owned());
         }
 
         if let Some(ref name) = extern_crate.name {
@@ -229,7 +229,7 @@ pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
                                   point: 0,
                                   local: false,
                                   mtype: Module,
-                                  contextstr: cratepath.to_str().unwrap().to_string(),
+                                  contextstr: cratepath.to_str().unwrap().to_owned(),
                                   generic_args: Vec::new(),
                                   generic_types: Vec::new(),
                                   session: core::Session::from_path(&cratepath.as_path(), &cratepath.as_path())
@@ -256,12 +256,12 @@ pub fn match_mod(msrc: &str, blobstart: usize, blobend: usize,
             debug!("found an inline module!");
 
             return Some(Match {
-                matchstr: l.to_string(),
+                matchstr: l.to_owned(),
                 filepath: filepath.to_path_buf(),
                 point: blobstart + start,
                 local: false,
                 mtype: Module,
-                contextstr: filepath.to_str().unwrap().to_string(),
+                contextstr: filepath.to_str().unwrap().to_owned(),
                 generic_args: Vec::new(),
                 generic_types: Vec::new(),
                 session: session.clone()
@@ -278,12 +278,12 @@ pub fn match_mod(msrc: &str, blobstart: usize, blobend: usize,
             }
             if let Some(modpath) = get_module_file(l, &searchdir) {
                 return Some(Match {
-                    matchstr: l.to_string(),
+                    matchstr: l.to_owned(),
                     filepath: modpath.to_path_buf(),
                     point: 0,
                     local: false,
                     mtype: Module,
-                    contextstr: modpath.to_str().unwrap().to_string(),
+                    contextstr: modpath.to_str().unwrap().to_owned(),
                     generic_args: Vec::new(),
                     generic_types: Vec::new(),
                     session: core::Session::from_path(&modpath, &modpath)
@@ -313,7 +313,7 @@ pub fn match_struct(msrc: &str, blobstart: usize, blobend: usize,
         let generics = ast::parse_generics(format!("{};", &blob[..end]));
 
         Some(Match {
-            matchstr: l.to_string(),
+            matchstr: l.to_owned(),
             filepath: filepath.to_path_buf(),
             point: blobstart + start,
             local: local,
@@ -340,7 +340,7 @@ pub fn match_type(msrc: &str, blobstart: usize, blobend: usize,
         };
         debug!("found!! a type {}", l);
         Some(Match {
-            matchstr: l.to_string(),
+            matchstr: l.to_owned(),
             filepath: filepath.to_path_buf(),
             point: blobstart + start,
             local: local,
@@ -367,7 +367,7 @@ pub fn match_trait(msrc: &str, blobstart: usize, blobend: usize,
         };
         debug!("found!! a trait {}", l);
         Some(Match {
-            matchstr: l.to_string(),
+            matchstr: l.to_owned(),
             filepath: filepath.to_path_buf(),
             point: blobstart + start,
             local: local,
@@ -391,7 +391,7 @@ pub fn match_enum_variants(msrc: &str, blobstart: usize, blobend: usize,
     if blob.starts_with("pub enum") || (local && blob.starts_with("enum")) {
         if txt_matches(search_type, searchstr, blob) {
             // parse the enum
-            let parsed_enum = ast::parse_enum(blob.to_string());
+            let parsed_enum = ast::parse_enum(blob.to_owned());
 
             for (name, offset) in parsed_enum.values.into_iter() {
                 if (&name).starts_with(searchstr) {
@@ -431,7 +431,7 @@ pub fn match_enum(msrc: &str, blobstart: usize, blobend: usize,
         let generics = ast::parse_generics(format!("{}{{}}", &blob[..end]));
 
         Some(Match {
-            matchstr: l.to_string(),
+            matchstr: l.to_owned(),
             filepath: filepath.to_path_buf(),
             point: blobstart + start,
             local: local,
@@ -463,7 +463,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
 
     if blob.contains("*") {
         // uh oh! a glob. Need to search the module for the searchstr
-        let use_item = ast::parse_use(blob.to_string());
+        let use_item = ast::parse_use(blob.to_owned());
         debug!("found a glob!! {:?}", use_item);
 
         if use_item.is_glob {
@@ -482,7 +482,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
             if follow_glob {
                 ALREADY_GLOBBING.with(|c| { c.set(Some(true)) });
 
-                let seg = PathSegment{ name: searchstr.to_string(), types: Vec::new() };
+                let seg = PathSegment{ name: searchstr.to_owned(), types: Vec::new() };
                 let mut path = basepath.clone();
                 path.segments.push(seg);
                 debug!("found a glob: now searching for {:?}", path);
@@ -501,9 +501,9 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
         }
     } else if txt_matches(search_type, searchstr, blob) {
         debug!("found use: {} in |{}|", searchstr, blob);
-        let use_item = ast::parse_use(blob.to_string());
+        let use_item = ast::parse_use(blob.to_owned());
 
-        let ident = use_item.ident.unwrap_or("".to_string());
+        let ident = use_item.ident.unwrap_or("".into());
         for path in use_item.paths.into_iter() {
             let len = path.segments.len();
 
@@ -561,7 +561,7 @@ pub fn match_fn(msrc: &str, blobstart: usize, blobend: usize,
             };
             debug!("found a fn {}", l);
             Some(Match {
-                matchstr: l.to_string(),
+                matchstr: l.to_owned(),
                 filepath: filepath.to_path_buf(),
                 point: blobstart + start,
                 local: local,

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -47,7 +47,7 @@ fn find_keyword(src: &str, pattern: &str, search: &str, search_type: SearchType,
             // remove whitespaces ... must have one at least
             start += pat.len();
             let oldstart = start;
-            for &b in src[start..].as_bytes().iter() {
+            for &b in src[start..].as_bytes() {
                 match b {
                     b' '|b'\r'|b'\n'|b'\t' => start += 1,
                     _ => break
@@ -62,7 +62,7 @@ fn find_keyword(src: &str, pattern: &str, search: &str, search_type: SearchType,
         // remove whitespaces ... must have one at least
         start += pattern.len();
         let oldstart = start;
-        for &b in src[start..].as_bytes().iter() {
+        for &b in src[start..].as_bytes() {
             match b {
                 b' '|b'\r'|b'\n'|b'\t' => start += 1,
                 _ => break
@@ -142,7 +142,7 @@ fn match_pattern_let(msrc: &str, blobstart: usize, blobend: usize,
     let blob = &msrc[blobstart..blobend];
     if blob.starts_with(pattern) && txt_matches(search_type, searchstr, blob) {
         let coords = ast::parse_let(blob.to_owned());
-        for &(start, end) in coords.iter() {
+        for (start, end) in coords {
             let s = &blob[start..end];
             if symbol_matches(search_type, searchstr, s) {
                 debug!("match_pattern_let point is {}", blobstart + start);

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -181,7 +181,7 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: &str, searchstr: 
             if txt_matches(search_type, searchstr, &*s) {
                 let mut out = matchers::match_if_let(&*s, 0, s.len(), searchstr,
                                                      filepath, search_type, true, &session);
-                for m in out.iter_mut() {
+                for m in &mut out {
                     m.point += ifletstart;
                 }
                 return out.into_iter();
@@ -223,7 +223,7 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: &str, searchstr: 
             debug!("PHIL arm lhs is |{}|", lhs);
             debug!("PHIL arm fauxmatchstmt is |{}|, {}", fauxmatchstmt, faux_prefix_size);
             let mut out = Vec::new();
-            for &(start,end) in ast::parse_pat_idents(fauxmatchstmt).iter() {
+            for (start,end) in ast::parse_pat_idents(fauxmatchstmt) {
                 let (start,end) = (lhs_start + start - faux_prefix_size,
                                    lhs_start + end - faux_prefix_size);
                 let s = &msrc[start..end];
@@ -283,7 +283,7 @@ fn search_fn_args(fnstart: usize, open_brace_pos: usize, msrc:&str, searchstr:&s
     if txt_matches(search_type, searchstr, &fndecl) {
         let coords = ast::parse_fn_args(fndecl.clone());
 
-        for &(start,end) in coords.iter() {
+        for (start,end) in coords {
             let s = &fndecl[start..end];
             debug!("search_fn_args: arg str is |{}|", s);
 
@@ -325,7 +325,7 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
                         v.push(dir_entry.path());
                     }
                 }
-                for fpath_buf in v.iter() {
+                for fpath_buf in v {
                     // skip filenames that can't be decoded
                     let fname = match fpath_buf.file_name().and_then(|n| n.to_str()) {
                         Some(fname) => fname,
@@ -402,7 +402,7 @@ pub fn search_crate_root(pathseg: &core::PathSegment, modfpath: &Path,
 
     let crateroots = find_possible_crate_root_modules(modfpath.parent().unwrap());
     let mut out = Vec::new();
-    for crateroot in crateroots.iter() {
+    for crateroot in &crateroots {
         if crateroot.deref() == modfpath {
             continue;
         }
@@ -638,7 +638,7 @@ pub fn search_scope(start: usize, point: usize, src: &str,
     }
 
     // finally process any use-globs that we skipped before
-    for &(blobstart, blobend) in delayed_use_globs.iter() {
+    for (blobstart, blobend) in delayed_use_globs {
         // There's a good chance of a match. Run the matchers
         for m in run_matchers_on_blob(src, start+blobstart, start+blobend,
                                       searchstr, filepath, search_type,
@@ -822,7 +822,7 @@ pub struct Search {
 
 pub fn is_a_repeat_search(new_search: &Search) -> bool {
     SEARCH_STACK.with(|v| {
-        for s in v.iter() {
+        for s in v {
             if s == new_search {
                 debug!("is a repeat search {:?} Stack: {:?}", new_search, v);
                 return true;

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -30,12 +30,12 @@ fn search_struct_fields(searchstr: &str, structmatch: &Match,
 
     for (field, fpos, _) in fields.into_iter() {
         if symbol_matches(search_type, searchstr, &field) {
-            out.push(Match { matchstr: field.to_string(),
+            out.push(Match { matchstr: field.clone(),
                                 filepath: structmatch.filepath.to_path_buf(),
                                 point: fpos + opoint.unwrap(),
                                 local: structmatch.local,
                                 mtype: StructField,
-                                contextstr: field.to_string(),
+                                contextstr: field,
                                 generic_args: Vec::new(), generic_types: Vec::new(),
                                 session: structmatch.session.clone()
             });

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -710,7 +710,7 @@ fn search_local_scopes(pathseg: &core::PathSegment, filepath: &Path,
 
     if point == 0 {
         // search the whole file
-        return search_scope(0, 0, msrc, pathseg, filepath, search_type, true, namespace, session);
+        search_scope(0, 0, msrc, pathseg, filepath, search_type, true, namespace, session)
     } else {
         let mut out = Vec::new();
         let mut start = point;
@@ -951,7 +951,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
     let len = path.segments.len();
     if len == 1 {
         let ref pathseg = path.segments[0];
-        return resolve_name(pathseg, filepath, pos, search_type, namespace, session);
+        resolve_name(pathseg, filepath, pos, search_type, namespace, session)
     } else if len != 0 {
         if path.segments[0].name == "self" {
             // just remove self

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -218,7 +218,7 @@ pub fn mask_sub_scopes(src: &str) -> String {
     let mut start = 0usize;
     let mut pos = 0usize;
 
-    for &b in src.as_bytes().iter() {
+    for &b in src.as_bytes() {
         pos += 1;
         match b {
             b'{' => {
@@ -280,7 +280,7 @@ pub fn point_to_coords(src: &str, point: usize) -> (usize, usize) {
     let mut i = 0;
     let mut linestart = 0;
     let mut nlines = 1;  // lines start at 1
-    for &b in src[..point].as_bytes().iter() {
+    for &b in src[..point].as_bytes() {
         i += 1;
         if b == b'\n' {
             nlines += 1;

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -98,7 +98,7 @@ fn finds_subnested_module() {
 }
 
 
-pub fn split_into_context_and_completion<'a>(s: &'a str) -> (&'a str, &'a str, core::CompletionType) {
+pub fn split_into_context_and_completion(s: &str) -> (&str, &str, core::CompletionType) {
     match s.char_indices().rev().find(|&(_, c)| !util::is_ident_char(c)) {
         Some((i,c)) => {
             //println!("PHIL s '{}' i {} c '{}'",s,i,c);
@@ -259,7 +259,7 @@ pub fn mask_sub_scopes(src: &str) -> String {
     result
 }
 
-pub fn end_of_next_scope<'a>(src: &'a str) -> &'a str {
+pub fn end_of_next_scope(src: &str) -> &str {
     match find_close(src.as_bytes().iter(), b'{', b'}', 1) {
         Some(count) => &src[..count+1],
         None => ""

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -11,7 +11,7 @@ pub fn snippet_for_match(m: &Match) -> String {
             if let Some(m) = MethodInfo::from_source_str(&method) {
                 m.snippet()
             } else {
-                "".to_string()
+                "".into()
             }
         }
         _ => m.matchstr.clone()
@@ -44,7 +44,7 @@ impl MethodInfo {
                                     let ref codemap = p.sess.span_diagnostic.cm;
                                     match codemap.span_to_snippet(arg.pat.span) {
                                         Ok(name) => name,
-                                        _ => "".to_string()
+                                        _ => "".into()
                                     }
                                 }).collect(),
                             })

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -51,13 +51,13 @@ impl MethodInfo {
                         },
                         _ => {
                             debug!("Unable to parse method declaration. |{}|", source);
-                            return None;
+                            None
                         }
                     }
                 },
                 Err(FatalError) => {
                     debug!("Unable to parse method declaration. |{}|",source);
-                    return None;
+                    None
                 }
             }
         })

--- a/src/racer/testutils.rs
+++ b/src/racer/testutils.rs
@@ -15,6 +15,6 @@ pub fn rejustify(src: &str) -> String {
 }
 
 #[cfg(test)]
-pub fn slice<'a>(src: &'a str, (begin, end): (usize, usize)) -> &'a str {
+pub fn slice(src: &str, (begin, end): (usize, usize)) -> &str {
     &src[begin..end]
 }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -56,7 +56,7 @@ fn get_type_of_self_arg(m: &Match, msrc: &str) -> Option<core::Ty> {
             return resolve_path_with_str(&implres.name_path.expect("failed parsing impl name"),
                                          &m.filepath, start,
                                          ExactMatch, TypeNamespace,
-                                         &m.session).nth(0).map(|m| core::Ty::TyMatch(m));
+                                         &m.session).nth(0).map(core::Ty::TyMatch);
         } else {
             // // must be a trait
             return ast::parse_trait(decl).name.and_then(|name| {

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -32,7 +32,7 @@ pub fn first_param_is_self(blob: &str) -> bool {
     blob.find("(").map_or(false, |start| {
         let end = scopes::find_closing_paren(blob, start+1);
         debug!("searching fn args: |{}| {}", &blob[(start+1)..end], txt_matches(ExactMatch, "self", &blob[(start+1)..end]));
-        return txt_matches(ExactMatch, "self", &blob[(start+1)..end]);
+        txt_matches(ExactMatch, "self", &blob[(start+1)..end])
     })
 }
 
@@ -46,20 +46,20 @@ fn generates_skeleton_for_mod() {
 fn get_type_of_self_arg(m: &Match, msrc: &str) -> Option<core::Ty> {
     assert_eq!(&m.filepath, &m.session.query_path);
     debug!("get_type_of_self_arg {:?}", m);
-    return scopes::find_impl_start(msrc, m.point, 0).and_then(|start| {
+    scopes::find_impl_start(msrc, m.point, 0).and_then(|start| {
         let decl = generate_skeleton_for_parsing(&msrc[start..]);
         debug!("get_type_of_self_arg impl skeleton |{}|", decl);
 
         if (&decl).starts_with("impl") {
             let implres = ast::parse_impl(decl);
             debug!("get_type_of_self_arg implres |{:?}|", implres);
-            return resolve_path_with_str(&implres.name_path.expect("failed parsing impl name"),
-                                         &m.filepath, start,
-                                         ExactMatch, TypeNamespace,
-                                         &m.session).nth(0).map(core::Ty::TyMatch);
+            resolve_path_with_str(&implres.name_path.expect("failed parsing impl name"),
+                                  &m.filepath, start,
+                                  ExactMatch, TypeNamespace,
+                                  &m.session).nth(0).map(core::Ty::TyMatch)
         } else {
             // // must be a trait
-            return ast::parse_trait(decl).name.and_then(|name| {
+            ast::parse_trait(decl).name.and_then(|name| {
                 Some(core::Ty::TyMatch(Match {
                            matchstr: name,
                            filepath: m.filepath.clone(),
@@ -70,9 +70,9 @@ fn get_type_of_self_arg(m: &Match, msrc: &str) -> Option<core::Ty> {
                            generic_args: Vec::new(), generic_types: Vec::new(),
                            session: m.session.clone()
                 }))
-            });
+            })
         }
-    });
+    })
 }
 
 fn get_type_of_fnarg(m: &Match, msrc: &str) -> Option<core::Ty> {
@@ -195,7 +195,7 @@ pub fn get_type_of_match(m: Match, msrc: &str) -> Option<core::Ty> {
     assert_eq!(&m.filepath, &m.session.query_path);
     debug!("get_type_of match {:?} ", m);
 
-    return match m.mtype {
+    match m.mtype {
         core::MatchType::Let => get_type_of_let_expr(&m, msrc),
         core::MatchType::IfLet => get_type_of_if_let_expr(&m, msrc),
         core::MatchType::FnArg => get_type_of_fnarg(&m, msrc),
@@ -237,14 +237,14 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str) -> Option<core::Ty> {
 
     debug!("fauxmatchstmt for parsing is pt:{} src:|{}|", faux_point, fauxmatchstmt);
 
-    return ast::get_match_arm_type(fauxmatchstmt, faux_point,
-                                   // scope is used to locate expression, so send
-                                   // it the start of the match expr
-                                   core::Scope {
-                                       filepath: m.filepath.clone(),
-                                       point: matchstart,
-                                       session: m.session.clone()
-                                   });
+    ast::get_match_arm_type(fauxmatchstmt, faux_point,
+                            // scope is used to locate expression, so send
+                            // it the start of the match expr
+                            core::Scope {
+                                filepath: m.filepath.clone(),
+                                point: matchstart,
+                                session: m.session.clone()
+                            })
 }
 
 pub fn get_function_declaration(fnmatch: &Match) -> String {
@@ -266,6 +266,6 @@ pub fn get_return_type_of_function(fnmatch: &Match) -> Option<core::Ty> {
         decl.push_str(&src[point..(point+n+1)]);
         decl.push_str("}}");
         debug!("get_return_type_of_function: passing in |{}|", decl);
-        return ast::parse_fn_output(decl, core::Scope::from_match(fnmatch));
+        ast::parse_fn_output(decl, core::Scope::from_match(fnmatch))
     })
 }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -109,7 +109,7 @@ fn get_type_of_let_expr(m: &Match, msrc: &str) -> Option<core::Ty> {
 
         let pos = m.point - point - start;
         let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point, session: m.session.clone()};
-        ast::get_let_type(blob.to_string(), pos, scope)
+        ast::get_let_type(blob.to_owned(), pos, scope)
     } else {
         None
     }
@@ -130,7 +130,7 @@ fn get_type_of_if_let_expr(m: &Match, msrc: &str) -> Option<core::Ty> {
 
         let pos = m.point - stmtstart - point - start;
         let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point, session: m.session.clone()};
-        ast::get_let_type(blob.to_string(), pos, scope)
+        ast::get_let_type(blob.to_owned(), pos, scope)
     } else {
         None
     }
@@ -145,7 +145,7 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match) -> Option<cor
     let opoint = scopes::find_stmt_start(&*src, structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
 
-    let fields = ast::parse_struct_fields(structsrc.to_string(), core::Scope::from_match(structmatch));
+    let fields = ast::parse_struct_fields(structsrc.to_owned(), core::Scope::from_match(structmatch));
     for (field, _, ty) in fields.into_iter() {
         if fieldname == field {
             return ty;
@@ -164,11 +164,11 @@ pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match) -> Option<
         let to = (&src[structmatch.point..]).find("(")
             .map(|n| scopes::find_closing_paren(&*src, structmatch.point + n+1))
             .unwrap();
-        "struct ".to_string() + &src[structmatch.point..(to+1)] + ";"
+        "struct ".to_owned() + &src[structmatch.point..(to+1)] + ";"
     } else {
         assert!(structmatch.mtype == core::MatchType::Struct);
         let opoint = scopes::find_stmt_start(&*src, structmatch.point);
-        get_first_stmt(&src[opoint.unwrap()..]).to_string()
+        get_first_stmt(&src[opoint.unwrap()..]).to_owned()
     };
 
     debug!("get_tuplestruct_field_type structsrc=|{}|", structsrc);
@@ -230,7 +230,7 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str) -> Option<core::Ty> {
     let lhs_start = scopes::get_start_of_pattern(msrc, arm);
     let lhs = &msrc[lhs_start..arm];
     // construct faux match statement and recreate point
-    let mut fauxmatchstmt = (&msrc[matchstart..scopestart]).to_string();
+    let mut fauxmatchstmt = (&msrc[matchstart..scopestart]).to_owned();
     let faux_prefix_size = fauxmatchstmt.len();
     fauxmatchstmt = fauxmatchstmt + lhs + " => () };";
     let faux_point = faux_prefix_size + (m.point - lhs_start);
@@ -252,7 +252,7 @@ pub fn get_function_declaration(fnmatch: &Match) -> String {
     let src = core::load_file(&fnmatch.filepath, &fnmatch.session);
     let start = scopes::find_stmt_start(&*src, fnmatch.point).unwrap();
     let end = (&src[start..]).find('{').unwrap();
-    (&src[start..end+start]).to_string()
+    (&src[start..end+start]).to_owned()
 }
 
 pub fn get_return_type_of_function(fnmatch: &Match) -> Option<core::Ty> {

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -34,7 +34,7 @@ pub fn is_ident_char(c: char) -> bool {
 }
 
 pub fn txt_matches(stype: SearchType, needle: &str, haystack: &str) -> bool {
-    return match stype {
+    match stype {
         ExactMatch => {
             let nlen = needle.len();
             let hlen = haystack.len();
@@ -53,7 +53,7 @@ pub fn txt_matches(stype: SearchType, needle: &str, haystack: &str) -> bool {
                 }
                 n += 1;
             }
-            return false;
+            false
         },
         StartsWith => {
             if needle.is_empty() {
@@ -69,7 +69,7 @@ pub fn txt_matches(stype: SearchType, needle: &str, haystack: &str) -> bool {
                 }
                 n += 1;
             }
-            return false;
+            false
         }
     }
 }

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -146,12 +146,8 @@ fn find_ident_end_unicode() {
     assert_eq!(10, find_ident_end("ends_in_µ", 0));
 }
 
-pub fn to_refs<'a>(v: &'a Vec<String>) -> Vec<&'a str> {
-    let mut out = Vec::new();
-    for item in v.iter() {
-        out.push(&item[..]);
-    }
-    out
+pub fn to_refs(v: &Vec<String>) -> Vec<&str> {
+    v.iter().map(|s| s.as_ref()).collect()
 }
 
 pub fn find_last_str(needle: &str, mut haystack: &str) -> Option<usize> {

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -18,7 +18,7 @@ pub fn getline(filepath: &Path, linenum: usize, session: &Session) -> String {
             return line.unwrap();
         }
     }
-    "not found".to_owned()
+    "not found".into()
 }
 
 pub fn is_pattern_char(c: char) -> bool {

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -15,10 +15,10 @@ pub fn getline(filepath: &Path, linenum: usize, session: &Session) -> String {
         //print!("{}", line);
         i += 1;
         if i == linenum {
-            return line.unwrap().to_string();
+            return line.unwrap();
         }
     }
-    "not found".to_string()
+    "not found".to_owned()
 }
 
 pub fn is_pattern_char(c: char) -> bool {


### PR DESCRIPTION
This is the result from running rust-clippy over the racer source.

It's probably best to review the commits individually.

Since a lot of "idiomatic rust" lints can be overruled by personal preference, please let me know which of these changes are not desired in the racer codebase.

There are also objective improvements, such as using `to_owned` which is faster for string conversion, and one instance of using `into_iter` to avoid string clones.