### PR TITLE
Cache file contents in the session(s)

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -82,7 +82,7 @@ fn complete(match_found: &Fn(Match), args: &[String]) {
             });
             let fpath = Path::new(fname);
             let session = core::Session::from_path(&fpath, &substitute_file);
-            let src = core::load_file(&fpath, &session);
+            let src = session.load_file(&fpath);
             let line = &getline(&substitute_file, linenum, &session);
             let (start, pos) = util::expand_ident(line, charnum);
             println!("PREFIX {},{},{}", start, pos, &line[start..pos]);
@@ -152,7 +152,7 @@ fn find_definition(args: &[String]) {
     });
     let fpath = Path::new(&fname);
     let session = core::Session::from_path(&fpath, &substitute_file);
-    let src = core::load_file(&fpath, &session);
+    let src = session.load_file(&fpath);
     let pos = scopes::coords_to_point(&src, linenum, charnum);
 
     core::find_definition(&src, &fpath, pos, &session).map(match_fn);

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -384,7 +384,7 @@ fn find_type_match(path: &core::Path, fpath: &Path, pos: usize, session: &Rc<cor
 fn get_type_of_typedef(m: Match) -> Option<Match> {
     assert_eq!(&m.filepath, &m.session.query_path);
     debug!("get_type_of_typedef match is {:?}", m);
-    let msrc = core::load_file_and_mask_comments(&m.filepath, &m.session);
+    let msrc = m.session.load_file_and_mask_comments(&m.filepath);
     let blobstart = m.point - 5;  // - 5 because 'type '
     let blob = &msrc[blobstart..];
 
@@ -422,9 +422,9 @@ impl<'v> visit::Visitor<'v> for ExprTypeVisitor {
                                  &self.scope.filepath,
                                  self.scope.point,
                                  &self.scope.session).and_then(|m| {
-                   let msrc = core::load_file_and_mask_comments(
-                       &m.filepath, &m.session);
-                   typeinf::get_type_of_match(m, &msrc)
+                                     let sess = m.session.clone();
+                                     let msrc = sess.load_file_and_mask_comments(&m.filepath);
+                                     typeinf::get_type_of_match(m, &msrc)
                                  });
             }
             ast::ExprCall(ref callee_expression, _/*ref arguments*/) => {

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -5,6 +5,7 @@ use core::Ty::{TyTuple, TyPathSearch, TyMatch, TyUnsupported};
 use codeiter;
 
 use std::path::Path;
+use std::rc::Rc;
 
 use syntex_syntax::ast;
 use syntex_syntax::codemap;
@@ -321,7 +322,7 @@ impl<'v> visit::Visitor<'v> for MatchTypeVisitor {
     }
 }
 
-fn resolve_ast_path(path: &ast::Path, filepath: &Path, pos: usize, session: &core::Session) -> Option<Match> {
+fn resolve_ast_path(path: &ast::Path, filepath: &Path, pos: usize, session: &Rc<core::Session>) -> Option<Match> {
     assert_eq!(&filepath, &session.query_path.as_path());
     debug!("resolve_ast_path {:?}", to_racer_path(path));
     nameres::resolve_path_with_str(&to_racer_path(path), filepath, pos, core::SearchType::ExactMatch, core::Namespace::BothNamespaces, session).nth(0)
@@ -350,7 +351,7 @@ fn path_to_match(ty: Ty) -> Option<Ty> {
     }
 }
 
-fn find_type_match(path: &core::Path, fpath: &Path, pos: usize, session: &core::Session) -> Option<Ty> {
+fn find_type_match(path: &core::Path, fpath: &Path, pos: usize, session: &Rc<core::Session>) -> Option<Ty> {
     assert_eq!(&fpath, &session.query_path.as_path());
     debug!("find_type_match {:?}", path);
     let res = resolve_path_with_str(path, fpath, pos, core::SearchType::ExactMatch,
@@ -565,7 +566,7 @@ fn find_type_match_including_generics(fieldtype: &core::Ty,
                                       filepath: &Path,
                                       pos: usize,
                                       structm: &core::Match,
-                                      session: &core::Session) -> Option<Ty>{
+                                      session: &Rc<core::Session>) -> Option<Ty>{
     assert_eq!(&structm.filepath, &structm.session.query_path);
     assert_eq!(&filepath, &session.query_path.as_path());
     let fieldtypepath = match *fieldtype {
@@ -902,7 +903,7 @@ pub fn parse_enum(s: String) -> EnumVisitor {
     v
 }
 
-pub fn get_type_of(exprstr: String, fpath: &Path, pos: usize, session: &core::Session) -> Option<Ty> {
+pub fn get_type_of(exprstr: String, fpath: &Path, pos: usize, session: &Rc<core::Session>) -> Option<Ty> {
     assert_eq!(&fpath, &session.query_path.as_path());
     let myfpath = fpath.clone();
     let startscope = Scope {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -9,7 +9,7 @@ use scopes;
 use nameres;
 use ast;
 
-#[derive(Debug,Clone,PartialEq)]
+#[derive(Debug,Clone,Copy,PartialEq)]
 pub enum MatchType {
     Struct,
     Module,
@@ -29,32 +29,24 @@ pub enum MatchType {
     Static
 }
 
-impl Copy for MatchType {}
-
-#[derive(Debug,Clone)]
+#[derive(Debug,Clone,Copy)]
 pub enum SearchType {
     ExactMatch,
     StartsWith
 }
 
-impl Copy for SearchType {}
-
-#[derive(Debug,Clone)]
+#[derive(Debug,Clone,Copy)]
 pub enum Namespace {
     TypeNamespace,
     ValueNamespace,
     BothNamespaces
 }
 
-impl Copy for Namespace {}
-
-#[derive(Debug,Clone)]
+#[derive(Debug,Clone,Copy)]
 pub enum CompletionType {
     CompleteField,
     CompletePath
 }
-
-impl Copy for CompletionType {}
 
 #[derive(Clone)]
 pub struct Match {

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -210,7 +210,7 @@ pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
             // real crate name (e.g. extern crate collections_core = "collections")
             // so we need to get the source text without scrubbed strings
 
-            let rawsrc = core::load_file(filepath, &session);
+            let rawsrc = session.load_file(filepath);
             let rawblob = &rawsrc[blobstart..blobend];
             debug!("found an extern crate (unscrubbed): |{}|", rawblob);
 

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -237,7 +237,7 @@ pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
                                   contextstr: cratepath.to_str().unwrap().to_owned(),
                                   generic_args: Vec::new(),
                                   generic_types: Vec::new(),
-                                  session: core::Session::from_path(&cratepath.as_path(), &cratepath.as_path())
+                                  session: session.derived(&cratepath.as_path())
                 });
             });
         }
@@ -291,7 +291,7 @@ pub fn match_mod(msrc: &str, blobstart: usize, blobend: usize,
                     contextstr: modpath.to_str().unwrap().to_owned(),
                     generic_args: Vec::new(),
                     generic_types: Vec::new(),
-                    session: core::Session::from_path(&modpath, &modpath)
+                    session: session.derived(&modpath)
                 })
             }
         }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -7,7 +7,6 @@ use core::MatchType::{Module, Function, Struct, Enum, FnArg, Trait, StructField,
 use core::Namespace::{self, TypeNamespace, ValueNamespace, BothNamespaces};
 use util::{symbol_matches, txt_matches, find_ident_end, path_exists};
 use cargo;
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::{self, vec};
 
@@ -391,13 +390,13 @@ pub fn search_crate_root(pathseg: &core::PathSegment, modfpath: &Path,
 
     let crateroots = find_possible_crate_root_modules(modfpath.parent().unwrap());
     let mut out = Vec::new();
-    for crateroot in &crateroots {
-        if crateroot.deref() == modfpath {
+    for crateroot in crateroots {
+        if *modfpath == *crateroot {
             continue;
         }
         debug!("going to search for {:?} in crateroot {:?}", pathseg, crateroot.to_str());
-        let newsession = core::Session::from_path(&crateroot, crateroot);
-        for m in resolve_name(pathseg, crateroot, 0, searchtype, namespace, &newsession) {
+        let newsession = core::Session::from_path(&crateroot, &crateroot);
+        for m in resolve_name(pathseg, &crateroot, 0, searchtype, namespace, &newsession) {
             out.push(m);
             if let ExactMatch = searchtype {
                 break;

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -1,7 +1,6 @@
 use {core, ast, codecleaner, codeiter, typeinf, util};
 use core::Session;
 
-use std::io::{BufRead, BufReader};
 use std::iter::Iterator;
 use std::path::Path;
 use std::str::from_utf8;
@@ -292,21 +291,15 @@ pub fn point_to_coords(src: &str, point: usize) -> (usize, usize) {
 
 pub fn point_to_coords_from_file(path: &Path, point: usize, session: &Session) -> Option<(usize, usize)> {
     let mut lineno = 0;
-    if let Ok(f) = session.open_file(path) {
-        let reader = BufReader::new(f);
-        let mut p = 0;
-        for line_r in reader.lines() {
-            let line = line_r.unwrap();
-            lineno += 1;
-            if point < (p + line.len()) {
-                return Some((lineno, point - p));
-            }
-            p += line.len() + 1;  // +1 for the newline char
+    let mut p = 0;
+    for line_r in session.load_file(path).lines() {
+        let line = line_r;
+        lineno += 1;
+        if point < (p + line.len()) {
+            return Some((lineno, point - p));
         }
-    } else {
-        error!("Could not open file: {:?}",path); 
+        p += line.len() + 1;  // +1 for the newline char
     }
-
     None
 }
 

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -140,7 +140,7 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match) -> Option<cor
     assert_eq!(&structmatch.filepath, &structmatch.session.query_path);
     assert!(structmatch.mtype == core::MatchType::Struct);
 
-    let src = core::load_file(&structmatch.filepath, &structmatch.session);
+    let src = structmatch.session.load_file(&structmatch.filepath);
 
     let opoint = scopes::find_stmt_start(&src, structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
@@ -156,8 +156,7 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match) -> Option<cor
 
 pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match) -> Option<core::Ty> {
     assert_eq!(&structmatch.filepath, &structmatch.session.query_path);
-    let src = core::load_file(&structmatch.filepath, 
-                              &structmatch.session);
+    let src = structmatch.session.load_file(&structmatch.filepath);
 
     let structsrc = if let core::MatchType::EnumVariant = structmatch.mtype {
         // decorate the enum variant src to make it look like a tuple struct
@@ -249,7 +248,7 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str) -> Option<core::Ty> {
 
 pub fn get_function_declaration(fnmatch: &Match) -> String {
     assert_eq!(&fnmatch.filepath, &fnmatch.session.query_path);
-    let src = core::load_file(&fnmatch.filepath, &fnmatch.session);
+    let src = fnmatch.session.load_file(&fnmatch.filepath);
     let start = scopes::find_stmt_start(&src, fnmatch.point).unwrap();
     let end = (&src[start..]).find('{').unwrap();
     (&src[start..end+start]).to_owned()
@@ -257,7 +256,7 @@ pub fn get_function_declaration(fnmatch: &Match) -> String {
 
 pub fn get_return_type_of_function(fnmatch: &Match) -> Option<core::Ty> {
     assert_eq!(&fnmatch.filepath, &fnmatch.session.query_path);
-    let src = core::load_file(&fnmatch.filepath, &fnmatch.session);
+    let src = fnmatch.session.load_file(&fnmatch.filepath);
     let point = scopes::find_stmt_start(&src, fnmatch.point).unwrap();
     (&src[point..]).find("{").and_then(|n| {
         // wrap in "impl blah { }" so that methods get parsed correctly too

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -168,14 +168,11 @@ pub fn char_at(src: &str, i: usize) -> char {
 // PD: short term replacement for path.exists() (PathExt trait). Replace once
 // that stabilizes
 pub fn path_exists<P: AsRef<Path>>(path: P) -> bool {
-    is_dir(path.as_ref()) || File::open(path).is_ok()
+    is_dir(&path) || File::open(path).is_ok()
 }
 
 // PD: short term replacement for path.is_dir() (PathExt trait). Replace once
 // that stabilizes
 pub fn is_dir<P: AsRef<Path>>(path: P) -> bool {
-    match std::fs::metadata(path) {
-        Ok(file_info) => file_info.is_dir(),
-        _ => false
-    }
+    std::fs::metadata(path).map(|info| info.is_dir()).unwrap_or(false)
 }


### PR DESCRIPTION
This series of commits makes an attempt to avoid re-reading files from disk over and over. It also makes all Session access use a `Rc` pointer, so that the session isn't cloned for every match.

This gives a large speedup in debug mode (doing `racer complete std::io::` drops from 1.14s to 0.48s on my machine), probably because the `BufReader` implementation is really slow when unoptimized. 

In a release build I get a ~25% speedup from 30ms to 22ms using kbknapp's method from here: https://gist.github.com/kbknapp/fb28a49d7a0fe8b8e400 - allocations are down from from 82k (19M bytes) to 56k (7M bytes).

In daemon mode every request creates its own root Session, so files are not cached. This is probably a good thing as long as the cache is never invalidated e.g. based on mtime.