### PR TITLE
Remove session references in Match and other objects

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -22,11 +22,9 @@ use racer::nameres::{do_file_search, do_external_search, PATH_SEP};
 use racer::scopes;
 #[cfg(not(test))]
 use std::path::Path;
-#[cfg(not(test))]
-use std::rc::Rc;
 
 #[cfg(not(test))]
-fn match_with_snippet_fn(m: Match, session: &Rc<core::Session>) {
+fn match_with_snippet_fn(m: Match, session: &core::Session) {
     let (linenum, charnum) = scopes::point_to_coords_from_file(&m.filepath, m.point, session).unwrap();
     if m.matchstr == "" {
         panic!("MATCHSTR is empty - waddup?");
@@ -44,7 +42,7 @@ fn match_with_snippet_fn(m: Match, session: &Rc<core::Session>) {
 }
 
 #[cfg(not(test))]
-fn match_fn(m: Match, session: &Rc<core::Session>) {
+fn match_fn(m: Match, session: &core::Session) {
     if let Some((linenum, charnum)) = scopes::point_to_coords_from_file(&m.filepath,
                                                                         m.point,
                                                                         session) {
@@ -61,7 +59,7 @@ fn match_fn(m: Match, session: &Rc<core::Session>) {
 }
 
 #[cfg(not(test))]
-fn complete(match_found: &Fn(Match, &Rc<core::Session>), args: &[String]) {
+fn complete(match_found: &Fn(Match, &core::Session), args: &[String]) {
     if args.len() < 2 {
         println!("Provide more arguments!");
         print_usage();

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -96,22 +96,20 @@ impl fmt::Debug for Match {
 #[derive(Clone)]
 pub struct Scope {
     pub filepath: path::PathBuf,
-    pub point: usize,
-    pub session: Rc<Session>
+    pub point: usize
 }
 
 impl Scope {
-    pub fn from_match(m: &Match, session: &Rc<Session>) -> Scope {
-        Scope{ filepath: m.filepath.clone(), point: m.point, session: session.clone() }
+    pub fn from_match(m: &Match) -> Scope {
+        Scope{ filepath: m.filepath.clone(), point: m.point }
     }
 }
 
 impl fmt::Debug for Scope {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Scope [{:?}, {:?}, {:?}]",
+        write!(f, "Scope [{:?}, {:?}]",
                self.filepath.to_str(),
-               self.point,
-               self.session)
+               self.point)
     }
 }
 
@@ -193,17 +191,15 @@ pub struct PathSegment {
 pub struct PathSearch {
     pub path: Path,
     pub filepath: path::PathBuf,
-    pub point: usize,
-    pub session: Rc<Session>
+    pub point: usize
 }
 
 impl fmt::Debug for PathSearch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Search [{:?}, {:?}, {:?}, {:?}]",
+        write!(f, "Search [{:?}, {:?}, {:?}]",
                self.path,
                self.filepath.to_str(),
-               self.point,
-               self.session)
+               self.point)
     }
 }
 

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -222,16 +222,16 @@ impl FileCache {
 pub struct Session {
     query_path: path::PathBuf,            // the input path of the query
     substitute_file: path::PathBuf,       // the temporary file
-    file_cache: Rc<FileCache>             // cache for file contents
+    file_cache: FileCache                 // cache for file contents
 }
 
 impl Session {
-    pub fn from_path(query_path: &path::Path, substitute_file: &path::Path) -> Rc<Session> {
-        Rc::new(Session {
+    pub fn from_path(query_path: &path::Path, substitute_file: &path::Path) -> Session {
+        Session {
             query_path: query_path.to_path_buf(),
             substitute_file: substitute_file.to_path_buf(),
-            file_cache: Rc::new(FileCache::new())
-        })
+            file_cache: FileCache::new()
+        }
     }
 
     pub fn open_file(&self, path: &path::Path) -> io::Result<File> {
@@ -279,7 +279,7 @@ impl Session {
 }
 
 
-pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize, session: &Rc<Session>) -> vec::IntoIter<Match> {
+pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize, session: &Session) -> vec::IntoIter<Match> {
     let start = scopes::get_start_of_search_expr(src, pos);
     let expr = &src[start..pos];
 
@@ -320,11 +320,11 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize, session:
     out.into_iter()
 }
 
-pub fn find_definition(src: &str, filepath: &path::Path, pos: usize, session: &Rc<Session>) -> Option<Match> {
+pub fn find_definition(src: &str, filepath: &path::Path, pos: usize, session: &Session) -> Option<Match> {
     find_definition_(src, filepath, pos, session)
 }
 
-pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: &Rc<Session>) -> Option<Match> {
+pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: &Session) -> Option<Match> {
     let (start, end) = scopes::expand_search_expr(src, pos);
     let expr = &src[start..end];
 

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -8,7 +8,6 @@ use core::Namespace::BothNamespaces;
 use std::cell::Cell;
 use std::path::Path;
 use std::{iter, option, vec};
-use std::rc::Rc;
 
 pub type MIter = option::IntoIter<Match>;
 pub type MChain<T> = iter::Chain<T, MIter>;
@@ -17,7 +16,7 @@ pub type MChain<T> = iter::Chain<T, MIter>;
 pub fn match_types(src: &str, blobstart: usize, blobend: usize,
                    searchstr: &str, filepath: &Path,
                    search_type: SearchType,
-                   local: bool, session: &Rc<core::Session>) -> iter::Chain<MChain<MChain<MChain<MChain<MChain<MIter>>>>>, vec::IntoIter<Match>> {
+                   local: bool, session: &core::Session) -> iter::Chain<MChain<MChain<MChain<MChain<MChain<MIter>>>>>, vec::IntoIter<Match>> {
     let it = match_extern_crate(src, blobstart, blobend, searchstr, filepath, search_type, session).into_iter();
     let it = it.chain(match_mod(src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
     let it = it.chain(match_struct(src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
@@ -181,7 +180,7 @@ pub fn first_line(blob: &str) -> String {
 
 pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
                           searchstr: &str, filepath: &Path, search_type: SearchType,
-                          session: &Rc<core::Session>) -> Option<Match> {
+                          session: &core::Session) -> Option<Match> {
     let mut res = None;
     let blob = &msrc[blobstart..blobend];
 
@@ -433,7 +432,7 @@ thread_local!(static ALREADY_GLOBBING: Cell<Option<bool>> = Cell::new(None));
 
 pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
              searchstr: &str, filepath: &Path, search_type: SearchType,
-             local: bool, session: &Rc<core::Session>) -> Vec<Match> {
+             local: bool, session: &core::Session) -> Vec<Match> {
     let mut out = Vec::new();
     let blob = &msrc[blobstart..blobend];
 

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -23,7 +23,7 @@ fn search_struct_fields(searchstr: &str, structmatch: &Match,
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
 
     let fields = ast::parse_struct_fields(structsrc.to_owned(),
-                                          core::Scope::from_match(structmatch, session));
+                                          core::Scope::from_match(structmatch));
 
     let mut out = Vec::new();
 
@@ -881,12 +881,12 @@ pub fn get_super_scope(filepath: &Path, pos: usize, session: &Rc<core::Session>)
         for filename in &[ "mod.rs", "lib.rs" ] {
             let fpath = moduledir.join(&filename);
             if path_exists(&fpath) {
-                return Some(core::Scope{ filepath: fpath, point: 0, session: session.clone() })
+                return Some(core::Scope{ filepath: fpath, point: 0 })
             }
         }
         None
     } else if path.len() == 1 {
-        Some(core::Scope{ filepath: filepath.to_path_buf(), point: 0, session: session.clone() })
+        Some(core::Scope{ filepath: filepath.to_path_buf(), point: 0 })
     } else {
         path.pop();
         let path = core::Path::from_svec(false, path);
@@ -895,8 +895,7 @@ pub fn get_super_scope(filepath: &Path, pos: usize, session: &Rc<core::Session>)
                             Namespace::TypeNamespace, session).nth(0)
             .and_then(|m| msrc[m.point..].find("{")
                       .map(|p| core::Scope{ filepath: filepath.to_path_buf(),
-                                             point:m.point + p + 1,
-                                             session: session.clone() }))
+                                             point:m.point + p + 1 }))
     }
 }
 
@@ -923,7 +922,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                 let mut newpath: core::Path = path.clone();
                 newpath.segments.remove(0);
                 return resolve_path(&newpath, &scope.filepath,
-                                    scope.point, search_type, namespace, &scope.session);
+                                    scope.point, search_type, namespace, session);
             } else {
                 // can't find super scope. Return no matches
                 debug!("can't resolve path {:?}, returning no matches", path);

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -1,13 +1,15 @@
 use ast::with_error_checking_parse;
+use core;
 use core::{Match, MatchType};
 use typeinf::get_function_declaration;
 
+use std::rc::Rc;
 use syntex_syntax::ast::ImplItem_;
 
-pub fn snippet_for_match(m: &Match) -> String {
+pub fn snippet_for_match(m: &Match, session: &Rc<core::Session>) -> String {
     match m.mtype {
         MatchType::Function => {
-            let method = get_function_declaration(&m);
+            let method = get_function_declaration(&m, session);
             if let Some(m) = MethodInfo::from_source_str(&method) {
                 m.snippet()
             } else {

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -3,10 +3,9 @@ use core;
 use core::{Match, MatchType};
 use typeinf::get_function_declaration;
 
-use std::rc::Rc;
 use syntex_syntax::ast::ImplItem_;
 
-pub fn snippet_for_match(m: &Match, session: &Rc<core::Session>) -> String {
+pub fn snippet_for_match(m: &Match, session: &core::Session) -> String {
     match m.mtype {
         MatchType::Function => {
             let method = get_function_declaration(&m, session);

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -12,6 +12,8 @@ use matchers;
 use core::SearchType::ExactMatch;
 use util::txt_matches;
 
+use std::rc::Rc;
+
 fn find_start_of_function_body(src: &str) -> usize {
     // TODO: this should ignore anything inside parens so as to skip the arg list
     src.find("{").unwrap()
@@ -43,8 +45,7 @@ fn generates_skeleton_for_mod() {
     assert_eq!("mod foo {};", out);
 }
 
-fn get_type_of_self_arg(m: &Match, msrc: &str) -> Option<core::Ty> {
-    assert_eq!(&m.filepath, &m.session.query_path);
+fn get_type_of_self_arg(m: &Match, msrc: &str, session: &Rc<core::Session>) -> Option<core::Ty> {
     debug!("get_type_of_self_arg {:?}", m);
     scopes::find_impl_start(msrc, m.point, 0).and_then(|start| {
         let decl = generate_skeleton_for_parsing(&msrc[start..]);
@@ -56,7 +57,7 @@ fn get_type_of_self_arg(m: &Match, msrc: &str) -> Option<core::Ty> {
             resolve_path_with_str(&implres.name_path.expect("failed parsing impl name"),
                                   &m.filepath, start,
                                   ExactMatch, TypeNamespace,
-                                  &m.session).nth(0).map(core::Ty::TyMatch)
+                                  session).nth(0).map(core::Ty::TyMatch)
         } else {
             // // must be a trait
             ast::parse_trait(decl).name.and_then(|name| {
@@ -67,18 +68,16 @@ fn get_type_of_self_arg(m: &Match, msrc: &str) -> Option<core::Ty> {
                            local: m.local,
                            mtype: core::MatchType::Trait,
                            contextstr: matchers::first_line(&msrc[start..]),
-                           generic_args: Vec::new(), generic_types: Vec::new(),
-                           session: m.session.clone()
+                           generic_args: Vec::new(), generic_types: Vec::new()
                 }))
             })
         }
     })
 }
 
-fn get_type_of_fnarg(m: &Match, msrc: &str) -> Option<core::Ty> {
-    assert_eq!(&m.filepath, &m.session.query_path);
+fn get_type_of_fnarg(m: &Match, msrc: &str, session: &Rc<core::Session>) -> Option<core::Ty> {
     if m.matchstr == "self" {
-        return get_type_of_self_arg(m, msrc);
+        return get_type_of_self_arg(m, msrc, session);
     }
 
     let stmtstart = scopes::find_stmt_start(msrc, m.point).unwrap();
@@ -92,13 +91,12 @@ fn get_type_of_fnarg(m: &Match, msrc: &str) -> Option<core::Ty> {
         s.push_str(&blob[..(find_start_of_function_body(blob)+1)]);
         s.push_str("}}");
         let argpos = m.point - (stmtstart+start) + impl_header_len;
-        return ast::parse_fn_arg_type(s, argpos, core::Scope::from_match(m));
+        return ast::parse_fn_arg_type(s, argpos, core::Scope::from_match(m, session));
     }
     None
 }
 
-fn get_type_of_let_expr(m: &Match, msrc: &str) -> Option<core::Ty> {
-    assert_eq!(&m.filepath, &m.session.query_path);
+fn get_type_of_let_expr(m: &Match, msrc: &str, session: &Rc<core::Session>) -> Option<core::Ty> {
     // ASSUMPTION: this is being called on a let decl
     let point = scopes::find_stmt_start(msrc, m.point).unwrap();
     let src = &msrc[point..];
@@ -108,15 +106,14 @@ fn get_type_of_let_expr(m: &Match, msrc: &str) -> Option<core::Ty> {
         debug!("get_type_of_let_expr calling parse_let |{}|", blob);
 
         let pos = m.point - point - start;
-        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point, session: m.session.clone()};
+        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point, session: session.clone()};
         ast::get_let_type(blob.to_owned(), pos, scope)
     } else {
         None
     }
 }
 
-fn get_type_of_if_let_expr(m: &Match, msrc: &str) -> Option<core::Ty> {
-    assert_eq!(&m.filepath, &m.session.query_path);
+fn get_type_of_if_let_expr(m: &Match, msrc: &str, session: &Rc<core::Session>) -> Option<core::Ty> {
     // ASSUMPTION: this is being called on an if let decl
     let stmtstart = scopes::find_stmt_start(msrc, m.point).unwrap();
     let stmt = &msrc[stmtstart..];
@@ -129,23 +126,22 @@ fn get_type_of_if_let_expr(m: &Match, msrc: &str) -> Option<core::Ty> {
         debug!("get_type_of_if_let_expr calling parse_if_let |{}|", blob);
 
         let pos = m.point - stmtstart - point - start;
-        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point, session: m.session.clone()};
+        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point, session: session.clone()};
         ast::get_let_type(blob.to_owned(), pos, scope)
     } else {
         None
     }
 }
 
-pub fn get_struct_field_type(fieldname: &str, structmatch: &Match) -> Option<core::Ty> {
-    assert_eq!(&structmatch.filepath, &structmatch.session.query_path);
+pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: &Rc<core::Session>) -> Option<core::Ty> {
     assert!(structmatch.mtype == core::MatchType::Struct);
 
-    let src = structmatch.session.load_file(&structmatch.filepath);
+    let src = session.load_file(&structmatch.filepath);
 
     let opoint = scopes::find_stmt_start(&src, structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
 
-    let fields = ast::parse_struct_fields(structsrc.to_owned(), core::Scope::from_match(structmatch));
+    let fields = ast::parse_struct_fields(structsrc.to_owned(), core::Scope::from_match(structmatch, session));
     for (field, _, ty) in fields.into_iter() {
         if fieldname == field {
             return ty;
@@ -154,9 +150,8 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match) -> Option<cor
     None
 }
 
-pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match) -> Option<core::Ty> {
-    assert_eq!(&structmatch.filepath, &structmatch.session.query_path);
-    let src = structmatch.session.load_file(&structmatch.filepath);
+pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match, session: &Rc<core::Session>) -> Option<core::Ty> {
+    let src = session.load_file(&structmatch.filepath);
 
     let structsrc = if let core::MatchType::EnumVariant = structmatch.mtype {
         // decorate the enum variant src to make it look like a tuple struct
@@ -172,7 +167,7 @@ pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match) -> Option<
 
     debug!("get_tuplestruct_field_type structsrc=|{}|", structsrc);
 
-    let fields = ast::parse_struct_fields(structsrc, core::Scope::from_match(structmatch));
+    let fields = ast::parse_struct_fields(structsrc, core::Scope::from_match(structmatch, session));
     let mut i = 0u32;
     for (_, _, ty) in fields.into_iter() {
         if i == fieldnum {
@@ -190,15 +185,14 @@ pub fn get_first_stmt(src: &str) -> &str {
     }
 }
 
-pub fn get_type_of_match(m: Match, msrc: &str) -> Option<core::Ty> {
-    assert_eq!(&m.filepath, &m.session.query_path);
+pub fn get_type_of_match(m: Match, msrc: &str, session: &Rc<core::Session>) -> Option<core::Ty> {
     debug!("get_type_of match {:?} ", m);
 
     match m.mtype {
-        core::MatchType::Let => get_type_of_let_expr(&m, msrc),
-        core::MatchType::IfLet => get_type_of_if_let_expr(&m, msrc),
-        core::MatchType::FnArg => get_type_of_fnarg(&m, msrc),
-        core::MatchType::MatchArm => get_type_from_match_arm(&m, msrc),
+        core::MatchType::Let => get_type_of_let_expr(&m, msrc, session),
+        core::MatchType::IfLet => get_type_of_if_let_expr(&m, msrc, session),
+        core::MatchType::FnArg => get_type_of_fnarg(&m, msrc, session),
+        core::MatchType::MatchArm => get_type_from_match_arm(&m, msrc, session),
         core::MatchType::Struct => Some(core::Ty::TyMatch(m)),
         core::MatchType::Enum => Some(core::Ty::TyMatch(m)),
         core::MatchType::Function => Some(core::Ty::TyMatch(m)),
@@ -211,9 +205,7 @@ macro_rules! otry {
     ($e:expr) => (match $e { Some(e) => e, None => return None })
 }
 
-pub fn get_type_from_match_arm(m: &Match, msrc: &str) -> Option<core::Ty> {
-    assert_eq!(&m.filepath, &m.session.query_path);
-
+pub fn get_type_from_match_arm(m: &Match, msrc: &str, session: &Rc<core::Session>) -> Option<core::Ty> {
     // We construct a faux match stmt and then parse it. This is because the
     // match stmt may be incomplete (half written) in the real code
 
@@ -242,21 +234,19 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str) -> Option<core::Ty> {
                             core::Scope {
                                 filepath: m.filepath.clone(),
                                 point: matchstart,
-                                session: m.session.clone()
+                                session: session.clone()
                             })
 }
 
-pub fn get_function_declaration(fnmatch: &Match) -> String {
-    assert_eq!(&fnmatch.filepath, &fnmatch.session.query_path);
-    let src = fnmatch.session.load_file(&fnmatch.filepath);
+pub fn get_function_declaration(fnmatch: &Match, session: &Rc<core::Session>) -> String {
+    let src = session.load_file(&fnmatch.filepath);
     let start = scopes::find_stmt_start(&src, fnmatch.point).unwrap();
     let end = (&src[start..]).find('{').unwrap();
     (&src[start..end+start]).to_owned()
 }
 
-pub fn get_return_type_of_function(fnmatch: &Match) -> Option<core::Ty> {
-    assert_eq!(&fnmatch.filepath, &fnmatch.session.query_path);
-    let src = fnmatch.session.load_file(&fnmatch.filepath);
+pub fn get_return_type_of_function(fnmatch: &Match, session: &Rc<core::Session>) -> Option<core::Ty> {
+    let src = session.load_file(&fnmatch.filepath);
     let point = scopes::find_stmt_start(&src, fnmatch.point).unwrap();
     (&src[point..]).find("{").and_then(|n| {
         // wrap in "impl blah { }" so that methods get parsed correctly too
@@ -265,6 +255,6 @@ pub fn get_return_type_of_function(fnmatch: &Match) -> Option<core::Ty> {
         decl.push_str(&src[point..(point+n+1)]);
         decl.push_str("}}");
         debug!("get_return_type_of_function: passing in |{}|", decl);
-        ast::parse_fn_output(decl, core::Scope::from_match(fnmatch))
+        ast::parse_fn_output(decl, core::Scope::from_match(fnmatch, session))
     })
 }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -91,7 +91,7 @@ fn get_type_of_fnarg(m: &Match, msrc: &str, session: &Rc<core::Session>) -> Opti
         s.push_str(&blob[..(find_start_of_function_body(blob)+1)]);
         s.push_str("}}");
         let argpos = m.point - (stmtstart+start) + impl_header_len;
-        return ast::parse_fn_arg_type(s, argpos, core::Scope::from_match(m, session));
+        return ast::parse_fn_arg_type(s, argpos, core::Scope::from_match(m), session);
     }
     None
 }
@@ -106,8 +106,8 @@ fn get_type_of_let_expr(m: &Match, msrc: &str, session: &Rc<core::Session>) -> O
         debug!("get_type_of_let_expr calling parse_let |{}|", blob);
 
         let pos = m.point - point - start;
-        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point, session: session.clone()};
-        ast::get_let_type(blob.to_owned(), pos, scope)
+        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point };
+        ast::get_let_type(blob.to_owned(), pos, scope, session)
     } else {
         None
     }
@@ -126,8 +126,8 @@ fn get_type_of_if_let_expr(m: &Match, msrc: &str, session: &Rc<core::Session>) -
         debug!("get_type_of_if_let_expr calling parse_if_let |{}|", blob);
 
         let pos = m.point - stmtstart - point - start;
-        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point, session: session.clone()};
-        ast::get_let_type(blob.to_owned(), pos, scope)
+        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point };
+        ast::get_let_type(blob.to_owned(), pos, scope, session)
     } else {
         None
     }
@@ -141,7 +141,7 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: &Rc<
     let opoint = scopes::find_stmt_start(&src, structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
 
-    let fields = ast::parse_struct_fields(structsrc.to_owned(), core::Scope::from_match(structmatch, session));
+    let fields = ast::parse_struct_fields(structsrc.to_owned(), core::Scope::from_match(structmatch));
     for (field, _, ty) in fields.into_iter() {
         if fieldname == field {
             return ty;
@@ -167,7 +167,7 @@ pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match, session: &
 
     debug!("get_tuplestruct_field_type structsrc=|{}|", structsrc);
 
-    let fields = ast::parse_struct_fields(structsrc, core::Scope::from_match(structmatch, session));
+    let fields = ast::parse_struct_fields(structsrc, core::Scope::from_match(structmatch));
     let mut i = 0u32;
     for (_, _, ty) in fields.into_iter() {
         if i == fieldnum {
@@ -234,8 +234,7 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str, session: &Rc<core::Session
                             core::Scope {
                                 filepath: m.filepath.clone(),
                                 point: matchstart,
-                                session: session.clone()
-                            })
+                            }, session)
 }
 
 pub fn get_function_declaration(fnmatch: &Match, session: &Rc<core::Session>) -> String {
@@ -255,6 +254,6 @@ pub fn get_return_type_of_function(fnmatch: &Match, session: &Rc<core::Session>)
         decl.push_str(&src[point..(point+n+1)]);
         decl.push_str("}}");
         debug!("get_return_type_of_function: passing in |{}|", decl);
-        ast::parse_fn_output(decl, core::Scope::from_match(fnmatch, session))
+        ast::parse_fn_output(decl, core::Scope::from_match(fnmatch))
     })
 }


### PR DESCRIPTION
As discussed in #364. Session is now passed explicitly to all functions that need it. `Match`, `Scope` and `PathSearch` don't have a session field anymore. As a result, we can drop the `Rc` around the session reference.

Interestingly, that means that a few functions gained the `session` argument, but a few others also lost it, because they only used the session to compare a match.session.filepath with another filepath in an `assert`.

You'll be happy to hear that this also brings a speedup of 1.1ms/21.8ms = 5% for the usual benchmark case.