### PR TITLE
ast: speed up ParseSess construction with terminal stderr

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -13,6 +13,7 @@ use syntex_syntax::parse::parser::Parser;
 use syntex_syntax::parse::{lexer, ParseSess};
 use syntex_syntax::ptr::P;
 use syntex_syntax::visit::{self, Visitor};
+use syntex_syntax::diagnostic::{ColorConfig, Handler, SpanHandler};
 
 // This code ripped from libsyntax::util::parser_testing
 pub fn string_to_parser(ps: &ParseSess, source_str: String) -> Option<Parser> {
@@ -23,7 +24,10 @@ pub fn string_to_parser(ps: &ParseSess, source_str: String) -> Option<Parser> {
 }
 
 pub fn with_error_checking_parse<F, T>(s: String, f: F) -> Option<T> where F: Fn(&mut Parser) -> Option<T> {
-    let ps = ParseSess::new();
+    let sh = SpanHandler::new(Handler::new(ColorConfig::Never, None, false),
+                              codemap::CodeMap::new());
+    let ps = ParseSess::with_span_handler(sh);
+
     let mut p = match string_to_parser(&ps, s) {
         Some(p) => p,
         None => return None


### PR DESCRIPTION
If racer runs with stderr going to a terminal this change saves a lot of time (>40%) reading terminfo files to determine color support, which is entirely unnecessary for racer.

This is probably mostly be relevant for people testing or benchmarking racer, since in normal use it will probably run with stderr going to a pipe or redirected to `/dev/null`.