### PR TITLE
create list of code indices immediately when loading files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typed-arena 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -109,6 +110,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ log = "*"
 syntex_syntax = "*"
 toml = "*"
 env_logger = "*"
+typed-arena = "*"
 
 [features]
 nightly = []

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -24,7 +24,7 @@ use racer::scopes;
 use std::path::Path;
 
 #[cfg(not(test))]
-fn match_with_snippet_fn(m: Match, session: &core::Session) {
+fn match_with_snippet_fn(m: Match, session: core::SessionRef) {
     let (linenum, charnum) = scopes::point_to_coords_from_file(&m.filepath, m.point, session).unwrap();
     if m.matchstr == "" {
         panic!("MATCHSTR is empty - waddup?");
@@ -42,7 +42,7 @@ fn match_with_snippet_fn(m: Match, session: &core::Session) {
 }
 
 #[cfg(not(test))]
-fn match_fn(m: Match, session: &core::Session) {
+fn match_fn(m: Match, session: core::SessionRef) {
     if let Some((linenum, charnum)) = scopes::point_to_coords_from_file(&m.filepath,
                                                                         m.point,
                                                                         session) {
@@ -59,7 +59,7 @@ fn match_fn(m: Match, session: &core::Session) {
 }
 
 #[cfg(not(test))]
-fn complete(match_found: &Fn(Match, &core::Session), args: &[String]) {
+fn complete(match_found: &Fn(Match, core::SessionRef), args: &[String]) {
     if args.len() < 2 {
         println!("Provide more arguments!");
         print_usage();

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -392,7 +392,7 @@ fn get_type_of_typedef(m: Match, session: SessionRef) -> Option<Match> {
     debug!("get_type_of_typedef match is {:?}", m);
     let msrc = session.load_file_and_mask_comments(&m.filepath);
     let blobstart = m.point - 5;  // - 5 because 'type '
-    let blob = &msrc[blobstart..];
+    let blob = msrc.from(blobstart);
 
     codeiter::iter_stmts(blob).nth(0).and_then(|(start, end)| {
         let blob = msrc[blobstart + start..blobstart+end].to_owned();
@@ -431,7 +431,7 @@ impl<'s, 'v> visit::Visitor<'v> for ExprTypeVisitor<'s> {
                                  self.scope.point,
                                  self.session).and_then(|m| {
                                      let msrc = self.session.load_file_and_mask_comments(&m.filepath);
-                                     typeinf::get_type_of_match(m, &msrc, self.session)
+                                     typeinf::get_type_of_match(m, msrc, self.session)
                                  });
             }
             ast::ExprCall(ref callee_expression, _/*ref arguments*/) => {

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -1,4 +1,4 @@
-use core::{self, Match, MatchType, Scope, Ty};
+use core::{self, Match, MatchType, Scope, Ty, SessionRef};
 use typeinf;
 use nameres::{self, resolve_path_with_str};
 use core::Ty::{TyTuple, TyPathSearch, TyMatch, TyUnsupported};
@@ -187,7 +187,7 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
                              point: usize,
                              ty: &Ty,
                              scope: &Scope,
-                             session: &core::Session) -> Option<Ty> {
+                             session: SessionRef) -> Option<Ty> {
     debug!("destructure_pattern_to_ty point {} ty {:?}    ||||||||    pat: {:?}", point, ty, pat);
     match pat.node {
         ast::PatIdent(_ , ref spannedident, _) => {
@@ -255,7 +255,7 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
 
 struct LetTypeVisitor<'s> {
     scope: Scope,
-    session: &'s core::Session,
+    session: SessionRef<'s>,
     srctxt: String,
     pos: usize,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
@@ -301,7 +301,7 @@ impl<'s, 'v> visit::Visitor<'v> for LetTypeVisitor<'s> {
 
 struct MatchTypeVisitor<'s> {
     scope: Scope,
-    session: &'s core::Session,
+    session: SessionRef<'s>,
     pos: usize,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
 }
@@ -331,7 +331,7 @@ impl<'s, 'v> visit::Visitor<'v> for MatchTypeVisitor<'s> {
     }
 }
 
-fn resolve_ast_path(path: &ast::Path, filepath: &Path, pos: usize, session: &core::Session) -> Option<Match> {
+fn resolve_ast_path(path: &ast::Path, filepath: &Path, pos: usize, session: SessionRef) -> Option<Match> {
     debug!("resolve_ast_path {:?}", to_racer_path(path));
     nameres::resolve_path_with_str(&to_racer_path(path), filepath, pos, core::SearchType::ExactMatch,
                                    core::Namespace::BothNamespaces, session).nth(0)
@@ -352,7 +352,7 @@ fn to_racer_path(pth: &ast::Path) -> core::Path {
     core::Path{ global: pth.global, segments: v }
 }
 
-fn path_to_match(ty: Ty, session: &core::Session) -> Option<Ty> {
+fn path_to_match(ty: Ty, session: SessionRef) -> Option<Ty> {
     match ty {
         TyPathSearch(ref path, ref scope) =>
             find_type_match(path, &scope.filepath, scope.point, session),
@@ -360,12 +360,12 @@ fn path_to_match(ty: Ty, session: &core::Session) -> Option<Ty> {
     }
 }
 
-fn find_type_match(path: &core::Path, fpath: &Path, pos: usize, session: &core::Session) -> Option<Ty> {
+fn find_type_match(path: &core::Path, fpath: &Path, pos: usize, session: SessionRef) -> Option<Ty> {
     debug!("find_type_match {:?}", path);
     let res = resolve_path_with_str(path, fpath, pos, core::SearchType::ExactMatch,
                core::Namespace::TypeNamespace, session).nth(0).and_then(|m| {
                    match m.mtype {
-                       core::MatchType::Type => get_type_of_typedef(m, session),
+                       MatchType::Type => get_type_of_typedef(m, session),
                        _ => Some(m)
                    }
                });
@@ -388,7 +388,7 @@ fn find_type_match(path: &core::Path, fpath: &Path, pos: usize, session: &core::
     })
 }
 
-fn get_type_of_typedef(m: Match, session: &core::Session) -> Option<Match> {
+fn get_type_of_typedef(m: Match, session: SessionRef) -> Option<Match> {
     debug!("get_type_of_typedef match is {:?}", m);
     let msrc = session.load_file_and_mask_comments(&m.filepath);
     let blobstart = m.point - 5;  // - 5 because 'type '
@@ -409,7 +409,7 @@ fn get_type_of_typedef(m: Match, session: &core::Session) -> Option<Match> {
 
 struct ExprTypeVisitor<'s> {
     scope: Scope,
-    session: &'s core::Session,
+    session: SessionRef<'s>,
     result: Option<Ty>,
 }
 
@@ -541,7 +541,7 @@ impl<'s, 'v> visit::Visitor<'v> for ExprTypeVisitor<'s> {
 }
 
 // gets generics info from the context match
-fn path_to_match_including_generics(ty: Ty, contextm: &core::Match, session: &core::Session) -> Option<Ty> {
+fn path_to_match_including_generics(ty: Ty, contextm: &Match, session: SessionRef) -> Option<Ty> {
     match ty {
         TyPathSearch(ref fieldtypepath, ref scope) => {
 
@@ -571,8 +571,8 @@ fn path_to_match_including_generics(ty: Ty, contextm: &core::Match, session: &co
 fn find_type_match_including_generics(fieldtype: &core::Ty,
                                       filepath: &Path,
                                       pos: usize,
-                                      structm: &core::Match,
-                                      session: &core::Session) -> Option<Ty>{
+                                      structm: &Match,
+                                      session: SessionRef) -> Option<Ty>{
     assert_eq!(&structm.filepath, &filepath.to_path_buf());
     let fieldtypepath = match *fieldtype {
         TyPathSearch(ref path, _) => path,
@@ -875,7 +875,7 @@ pub fn parse_fn_output(s: String, scope: Scope) -> Option<core::Ty> {
     v.result
 }
 
-pub fn parse_fn_arg_type(s: String, argpos: usize, scope: Scope, session: &core::Session) -> Option<core::Ty> {
+pub fn parse_fn_arg_type(s: String, argpos: usize, scope: Scope, session: SessionRef) -> Option<core::Ty> {
     debug!("parse_fn_arg {} |{}|", argpos, s);
     let mut v = FnArgTypeVisitor { argpos: argpos, scope: scope, result: None,
                                    session: session };
@@ -909,7 +909,7 @@ pub fn parse_enum(s: String) -> EnumVisitor {
     v
 }
 
-pub fn get_type_of(exprstr: String, fpath: &Path, pos: usize, session: &core::Session) -> Option<Ty> {
+pub fn get_type_of(exprstr: String, fpath: &Path, pos: usize, session: SessionRef) -> Option<Ty> {
     let myfpath = fpath.clone();
     let startscope = Scope {
         filepath: myfpath.to_path_buf(),
@@ -925,7 +925,7 @@ pub fn get_type_of(exprstr: String, fpath: &Path, pos: usize, session: &core::Se
 }
 
 // pos points to an ident in the lhs of the stmtstr
-pub fn get_let_type(stmtstr: String, pos: usize, scope: Scope, session: &core::Session) -> Option<Ty> {
+pub fn get_let_type(stmtstr: String, pos: usize, scope: Scope, session: SessionRef) -> Option<Ty> {
     let mut v = LetTypeVisitor {
         scope: scope,
         session: session,
@@ -938,7 +938,7 @@ pub fn get_let_type(stmtstr: String, pos: usize, scope: Scope, session: &core::S
     v.result
 }
 
-pub fn get_match_arm_type(stmtstr: String, pos: usize, scope: Scope, session: &core::Session) -> Option<Ty> {
+pub fn get_match_arm_type(stmtstr: String, pos: usize, scope: Scope, session: SessionRef) -> Option<Ty> {
     let mut v = MatchTypeVisitor {
         scope: scope,
         session: session,
@@ -969,7 +969,7 @@ impl<'v> visit::Visitor<'v> for FnOutputVisitor {
 pub struct FnArgTypeVisitor<'s> {
     argpos: usize,
     scope: Scope,
-    session: &'s core::Session,
+    session: SessionRef<'s>,
     pub result: Option<Ty>
 }
 

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -230,6 +230,8 @@ pub struct Session {
     file_cache: FileCache                 // cache for file contents
 }
 
+pub type SessionRef<'s> = &'s Session;
+
 impl Session {
     pub fn from_path(query_path: &path::Path, substitute_file: &path::Path) -> Session {
         Session {
@@ -284,7 +286,7 @@ impl Session {
 }
 
 
-pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize, session: &Session) -> vec::IntoIter<Match> {
+pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize, session: SessionRef) -> vec::IntoIter<Match> {
     let start = scopes::get_start_of_search_expr(src, pos);
     let expr = &src[start..pos];
 
@@ -325,11 +327,11 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize, session:
     out.into_iter()
 }
 
-pub fn find_definition(src: &str, filepath: &path::Path, pos: usize, session: &Session) -> Option<Match> {
+pub fn find_definition(src: &str, filepath: &path::Path, pos: usize, session: SessionRef) -> Option<Match> {
     find_definition_(src, filepath, pos, session)
 }
 
-pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: &Session) -> Option<Match> {
+pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: SessionRef) -> Option<Match> {
     let (start, end) = scopes::expand_search_expr(src, pos);
     let expr = &src[start..end];
 

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -5,7 +5,10 @@
 extern crate syntex_syntax;
 extern crate toml;
 extern crate env_logger;
+extern crate typed_arena;
 
+#[macro_use]
+pub mod testutils;
 pub mod core;
 pub mod scopes;
 pub mod ast;
@@ -13,9 +16,7 @@ pub mod typeinf;
 pub mod nameres;
 pub mod codeiter;
 pub mod codecleaner;
-pub mod testutils;
 pub mod util;
 pub mod matchers;
 pub mod snippets;
 pub mod cargo;
-

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -2,7 +2,7 @@
 
 use {core, ast, codeiter, matchers, scopes, typeinf, util};
 use core::SearchType::{self, ExactMatch, StartsWith};
-use core::{Match, SessionRef};
+use core::{Match, Src, SessionRef};
 use core::MatchType::{Module, Function, Struct, Enum, FnArg, Trait, StructField, Impl, MatchArm};
 use core::Namespace::{self, TypeNamespace, ValueNamespace, BothNamespaces};
 use util::{symbol_matches, txt_matches, find_ident_end, path_exists};
@@ -18,7 +18,7 @@ pub const PATH_SEP: &'static str = ";";
 fn search_struct_fields(searchstr: &str, structmatch: &Match,
                         search_type: SearchType, session: SessionRef) -> vec::IntoIter<Match> {
     let src = session.load_file(&structmatch.filepath);
-    let opoint = scopes::find_stmt_start(&src, structmatch.point);
+    let opoint = scopes::find_stmt_start(src, structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
 
     let fields = ast::parse_struct_fields(structsrc.to_owned(),
@@ -57,7 +57,7 @@ pub fn search_for_impl_methods(implsearchstr: &str,
         // find the opening brace and skip to it.
         (&src[m.point..]).find("{").map(|n| {
             let point = m.point + n + 1;
-            for m in search_scope_for_methods(point, &src, fieldsearchstr, &m.filepath, search_type) {
+            for m in search_scope_for_methods(point, src, fieldsearchstr, &m.filepath, search_type) {
                 out.push(m);
             }
         });
@@ -65,11 +65,11 @@ pub fn search_for_impl_methods(implsearchstr: &str,
     out.into_iter()
 }
 
-fn search_scope_for_methods(point: usize, src: &str, searchstr: &str, filepath: &Path,
+fn search_scope_for_methods(point: usize, src: Src, searchstr: &str, filepath: &Path,
                             search_type: SearchType) -> vec::IntoIter<Match> {
     debug!("searching scope for methods {} |{}| {:?}", point, searchstr, filepath.to_str());
 
-    let scopesrc = &src[point..];
+    let scopesrc = src.from(point);
     let mut out = Vec::new();
     for (blobstart,blobend) in codeiter::iter_stmts(scopesrc) {
         let blob = &scopesrc[blobstart..blobend];
@@ -105,7 +105,7 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
                         session: SessionRef) -> vec::IntoIter<Match> {
     debug!("search_for_impls {}, {}, {:?}", pos, searchstr, filepath.to_str());
     let s = session.load_file(filepath);
-    let src = &s[pos..];
+    let src = s.from(pos);
 
     let mut out = Vec::new();
     for (start, end) in codeiter::iter_stmts(src) {
@@ -152,7 +152,7 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
 }
 
 // scope headers include fn decls, if let, while let etc..
-fn search_scope_headers(point: usize, scopestart: usize, msrc: &str, searchstr: &str,
+fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &str,
                         filepath: &Path, search_type: SearchType) -> vec::IntoIter<Match> {
     debug!("search_scope_headers for |{}| pt: {}", searchstr, scopestart);
     if let Some(stmtstart) = scopes::find_stmt_start(msrc, scopestart) {
@@ -160,14 +160,14 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: &str, searchstr: 
         debug!("PHIL search_scope_headers preblock is |{}|", preblock);
 
         if preblock.starts_with("fn") || preblock.starts_with("pub fn") {
-            return search_fn_args(stmtstart, scopestart, msrc, searchstr, filepath, search_type, true);
+            return search_fn_args(stmtstart, scopestart, &msrc, searchstr, filepath, search_type, true);
 
         // 'if let' can be an expression, so might not be at the start of the stmt
         } else if let Some(n) = preblock.find("if let") {
             let ifletstart = stmtstart + n;
-            let s = (&msrc[ifletstart..scopestart+1]).to_owned() + "}";
-            if txt_matches(search_type, searchstr, &s) {
-                let mut out = matchers::match_if_let(&s, 0, s.len(), searchstr,
+            let src = (&msrc[ifletstart..scopestart+1]).to_owned() + "}";
+            if txt_matches(search_type, searchstr, &src) {
+                let mut out = matchers::match_if_let(&src, 0, src.len(), searchstr,
                                                      filepath, search_type, true);
                 for m in &mut out {
                     m.point += ifletstart;
@@ -177,11 +177,11 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: &str, searchstr: 
         } else if let Some(n) = util::find_last_str("match ", preblock) {
             // TODO: this code is crufty. refactor me!
             let matchstart = stmtstart + n;
-            let matchstmt = typeinf::get_first_stmt(&msrc[matchstart..]);
+            let matchstmt = typeinf::get_first_stmt(msrc.from(matchstart));
             // The definition could be in the match LHS arms. Try to find this
-            let masked_matchstmt = mask_matchstmt(matchstmt, scopestart + 1 - matchstart);
+            let masked_matchstmt = mask_matchstmt(&matchstmt, scopestart + 1 - matchstart);
             debug!("found match stmt, masked is len {} |{}|",
-                masked_matchstmt.len(), masked_matchstmt);
+                   masked_matchstmt.len(), masked_matchstmt);
 
             // Locate the match arm LHS by finding the => just before point and then backtracking
             // be sure to be on the right side of the ... => ... arm
@@ -201,7 +201,7 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: &str, searchstr: 
 
             debug!("PHIL matched arm rhs is |{}|", &masked_matchstmt[arm..]);
 
-            let lhs_start = scopes::get_start_of_pattern(msrc, matchstart + arm);
+            let lhs_start = scopes::get_start_of_pattern(&msrc, matchstart + arm);
             let lhs = &msrc[lhs_start..matchstart + arm];
 
             // Now create a pretend match expression with just the one match arm in it
@@ -246,7 +246,7 @@ fn mask_matchstmt(matchstmt_src: &str, innerscope_start: usize) -> String {
 
 #[test]
 fn does_it() {
-    let src : &str = "
+    let src = "
     match foo {
         Some(a) => { something }
     }";
@@ -432,7 +432,7 @@ pub fn search_next_scope(mut startpoint: usize, pathseg: &core::PathSegment,
             startpoint = startpoint + n + 1;
         });
     }
-    search_scope(startpoint, startpoint, &filesrc, pathseg, filepath, search_type, local, namespace, session)
+    search_scope(startpoint, startpoint, filesrc, pathseg, filepath, search_type, local, namespace, session)
 }
 
 pub fn get_crate_file(name: &str, from_path: &Path) -> Option<PathBuf> {
@@ -482,7 +482,7 @@ pub fn get_module_file(name: &str, parentdir: &Path) -> Option<PathBuf> {
     None
 }
 
-pub fn search_scope(start: usize, point: usize, src: &str,
+pub fn search_scope(start: usize, point: usize, src: Src,
                     pathseg: &core::PathSegment,
                     filepath:&Path, search_type: SearchType, local: bool,
                     namespace: Namespace,
@@ -493,7 +493,7 @@ pub fn search_scope(start: usize, point: usize, src: &str,
     debug!("searching scope {:?} start: {} point: {} '{}' {:?} {:?} local: {}, session: {:?}",
            namespace, start, point, searchstr, filepath.to_str(), search_type, local, session);
 
-    let scopesrc = &src[start..];
+    let scopesrc = src.from(start);
     let mut skip_next_block = false;
     let mut delayed_use_globs = Vec::new();
     let mut codeit = codeiter::iter_stmts(scopesrc);
@@ -531,7 +531,7 @@ pub fn search_scope(start: usize, point: usize, src: &str,
             continue;
         }
 
-        for m in matchers::match_let(src, start+blobstart,
+        for m in matchers::match_let(&src, start+blobstart,
                                      start+blobend,
                                      searchstr,
                                      filepath, search_type, local).into_iter() {
@@ -619,7 +619,7 @@ pub fn search_scope(start: usize, point: usize, src: &str,
     out.into_iter()
 }
 
-fn run_matchers_on_blob(src: &str, start: usize, end: usize, searchstr: &str,
+fn run_matchers_on_blob(src: Src, start: usize, end: usize, searchstr: &str,
                          filepath: &Path, search_type: SearchType, local: bool,
                          namespace: Namespace, session: SessionRef) -> Vec<Match> {
     let mut out = Vec::new();
@@ -665,7 +665,7 @@ fn run_matchers_on_blob(src: &str, start: usize, end: usize, searchstr: &str,
 }
 
 fn search_local_scopes(pathseg: &core::PathSegment, filepath: &Path,
-                       msrc: &str, point: usize, search_type: SearchType,
+                       msrc: Src, point: usize, search_type: SearchType,
                        namespace: Namespace,
                        session: SessionRef) -> vec::IntoIter<Match> {
     debug!("search_local_scopes {:?} {:?} {} {:?} {:?}", pathseg, filepath.to_str(), point,
@@ -724,7 +724,7 @@ pub fn search_prelude_file(pathseg: &core::PathSegment, search_type: SearchType,
         if path_exists(&filepath) {
             let msrc = session.load_file_and_mask_comments(&filepath);
             let is_local = true;
-            for m in search_scope(0, 0, &msrc, pathseg, &filepath, search_type, is_local, namespace, session) {
+            for m in search_scope(0, 0, msrc, pathseg, &filepath, search_type, is_local, namespace, session) {
                 out.push(m);
             }
         }
@@ -826,7 +826,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
 
 
 
-    for m in search_local_scopes(pathseg, filepath, &msrc, pos, search_type, namespace, session) {
+    for m in search_local_scopes(pathseg, filepath, msrc, pos, search_type, namespace, session) {
         out.push(m);
         if let ExactMatch = search_type {
             if !out.is_empty() {
@@ -864,7 +864,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
 // Get the scope corresponding to super::
 pub fn get_super_scope(filepath: &Path, pos: usize, session: SessionRef) -> Option<core::Scope> {
     let msrc = session.load_file_and_mask_comments(filepath);
-    let mut path = scopes::get_local_module_path(&msrc, pos);
+    let mut path = scopes::get_local_module_path(msrc, pos);
     debug!("get_super_scope: path: {:?} filepath: {:?} {} {:?}", path, filepath, pos, session);
     if path.is_empty() {
         let moduledir;
@@ -947,8 +947,8 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                     debug!("searching an enum '{}' (whole path: {:?}) searchtype: {:?}", m.matchstr, path, search_type);
 
                     let filesrc = session.load_file(&m.filepath);
-                    let scopestart = scopes::find_stmt_start(&filesrc, m.point).unwrap();
-                    let scopesrc = &filesrc[scopestart..];
+                    let scopestart = scopes::find_stmt_start(filesrc, m.point).unwrap();
+                    let scopesrc = filesrc.from(scopestart);
                     codeiter::iter_stmts(scopesrc).nth(0).map(|(blobstart,blobend)| {
                         for m in matchers::match_enum_variants(&filesrc,
                                                                scopestart+blobstart,
@@ -968,7 +968,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                         // find the opening brace and skip to it.
                         (&src[m.point..]).find("{").map(|n| {
                             let point = m.point + n + 1;
-                            for m in search_scope(point, point, &src, pathseg, &m.filepath, search_type, m.local, namespace, session) {
+                            for m in search_scope(point, point, src, pathseg, &m.filepath, search_type, m.local, namespace, session) {
                                 out.push(m);
                             }
                         });
@@ -1084,7 +1084,7 @@ pub fn search_for_field_or_method(context: Match, searchstr: &str, search_type: 
             let src = session.load_file(&m.filepath);
             (&src[m.point..]).find("{").map(|n| {
                 let point = m.point + n + 1;
-                for m in search_scope_for_methods(point, &src, searchstr, &m.filepath, search_type) {
+                for m in search_scope_for_methods(point, src, searchstr, &m.filepath, search_type) {
                     out.push(m);
                 }
             });

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -2,7 +2,7 @@
 
 use {core, ast, codeiter, matchers, scopes, typeinf, util};
 use core::SearchType::{self, ExactMatch, StartsWith};
-use core::Match;
+use core::{Match, SessionRef};
 use core::MatchType::{Module, Function, Struct, Enum, FnArg, Trait, StructField, Impl, MatchArm};
 use core::Namespace::{self, TypeNamespace, ValueNamespace, BothNamespaces};
 use util::{symbol_matches, txt_matches, find_ident_end, path_exists};
@@ -16,7 +16,7 @@ pub const PATH_SEP: &'static str = ":";
 pub const PATH_SEP: &'static str = ";";
 
 fn search_struct_fields(searchstr: &str, structmatch: &Match,
-                        search_type: SearchType, session: &core::Session) -> vec::IntoIter<Match> {
+                        search_type: SearchType, session: SessionRef) -> vec::IntoIter<Match> {
     let src = session.load_file(&structmatch.filepath);
     let opoint = scopes::find_stmt_start(&src, structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
@@ -45,7 +45,7 @@ pub fn search_for_impl_methods(implsearchstr: &str,
                            fieldsearchstr: &str, point: usize,
                            fpath: &Path, local: bool,
                            search_type: SearchType,
-                           session: &core::Session) -> vec::IntoIter<Match> {
+                               session: SessionRef) -> vec::IntoIter<Match> {
     debug!("searching for impl methods |{}| |{}| {:?}", implsearchstr, fieldsearchstr, fpath.to_str());
 
     let mut out = Vec::new();
@@ -102,7 +102,7 @@ fn search_scope_for_methods(point: usize, src: &str, searchstr: &str, filepath: 
 
 
 pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: bool, include_traits: bool,
-                        session: &core::Session) -> vec::IntoIter<Match> {
+                        session: SessionRef) -> vec::IntoIter<Match> {
     debug!("search_for_impls {}, {}, {:?}", pos, searchstr, filepath.to_str());
     let s = session.load_file(filepath);
     let src = &s[pos..];
@@ -366,7 +366,7 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
 
 pub fn search_crate_root(pathseg: &core::PathSegment, modfpath: &Path,
                          searchtype: SearchType, namespace: Namespace,
-                         session: &core::Session) -> vec::IntoIter<Match> {
+                         session: SessionRef) -> vec::IntoIter<Match> {
     debug!("search_crate_root |{:?}| {:?}", pathseg, modfpath.to_str());
 
     let crateroots = find_possible_crate_root_modules(modfpath.parent().unwrap());
@@ -420,7 +420,7 @@ pub fn find_possible_crate_root_modules(currentdir: &Path) -> Vec<PathBuf> {
 pub fn search_next_scope(mut startpoint: usize, pathseg: &core::PathSegment,
                          filepath:&Path, search_type: SearchType, local: bool,
                          namespace: Namespace,
-                         session: &core::Session) -> vec::IntoIter<Match> {
+                         session: SessionRef) -> vec::IntoIter<Match> {
     let filesrc = session.load_file(filepath);
     if startpoint != 0 {
         // is a scope inside the file. Point should point to the definition
@@ -486,7 +486,7 @@ pub fn search_scope(start: usize, point: usize, src: &str,
                     pathseg: &core::PathSegment,
                     filepath:&Path, search_type: SearchType, local: bool,
                     namespace: Namespace,
-                    session: &core::Session) -> vec::IntoIter<Match> {
+                    session: SessionRef) -> vec::IntoIter<Match> {
     let searchstr = &pathseg.name;
     let mut out = Vec::new();
 
@@ -621,7 +621,7 @@ pub fn search_scope(start: usize, point: usize, src: &str,
 
 fn run_matchers_on_blob(src: &str, start: usize, end: usize, searchstr: &str,
                          filepath: &Path, search_type: SearchType, local: bool,
-                         namespace: Namespace, session: &core::Session) -> Vec<Match> {
+                         namespace: Namespace, session: SessionRef) -> Vec<Match> {
     let mut out = Vec::new();
     match namespace {
         TypeNamespace =>
@@ -667,7 +667,7 @@ fn run_matchers_on_blob(src: &str, start: usize, end: usize, searchstr: &str,
 fn search_local_scopes(pathseg: &core::PathSegment, filepath: &Path,
                        msrc: &str, point: usize, search_type: SearchType,
                        namespace: Namespace,
-                       session: &core::Session) -> vec::IntoIter<Match> {
+                       session: SessionRef) -> vec::IntoIter<Match> {
     debug!("search_local_scopes {:?} {:?} {} {:?} {:?}", pathseg, filepath.to_str(), point,
            search_type, namespace);
 
@@ -705,7 +705,7 @@ fn search_local_scopes(pathseg: &core::PathSegment, filepath: &Path,
 }
 
 pub fn search_prelude_file(pathseg: &core::PathSegment, search_type: SearchType,
-                           namespace: Namespace, session: &core::Session) -> vec::IntoIter<Match> {
+                           namespace: Namespace, session: SessionRef) -> vec::IntoIter<Match> {
     debug!("search_prelude file {:?} {:?} {:?}", pathseg, search_type, namespace);
 //    debug!("PHIL searching prelude file, backtrace: {}",util::get_backtrace());
 
@@ -734,7 +734,7 @@ pub fn search_prelude_file(pathseg: &core::PathSegment, search_type: SearchType,
 
 pub fn resolve_path_with_str(path: &core::Path, filepath: &Path, pos: usize,
                                    search_type: SearchType, namespace: Namespace,
-                                   session: &core::Session) -> vec::IntoIter<Match> {
+                                   session: SessionRef) -> vec::IntoIter<Match> {
     debug!("resolve_path_with_str {:?}", path);
 
     let mut out = Vec::new();
@@ -794,7 +794,7 @@ pub fn is_a_repeat_search(new_search: &Search) -> bool {
 
 pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
                     search_type: SearchType, namespace: Namespace,
-                    session: &core::Session) -> vec::IntoIter<Match> {
+                    session: SessionRef) -> vec::IntoIter<Match> {
     let mut out = Vec::new();
     let searchstr = &pathseg.name;
 
@@ -862,7 +862,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
 }
 
 // Get the scope corresponding to super::
-pub fn get_super_scope(filepath: &Path, pos: usize, session: &core::Session) -> Option<core::Scope> {
+pub fn get_super_scope(filepath: &Path, pos: usize, session: SessionRef) -> Option<core::Scope> {
     let msrc = session.load_file_and_mask_comments(filepath);
     let mut path = scopes::get_local_module_path(&msrc, pos);
     debug!("get_super_scope: path: {:?} filepath: {:?} {} {:?}", path, filepath, pos, session);
@@ -900,7 +900,7 @@ pub fn get_super_scope(filepath: &Path, pos: usize, session: &core::Session) -> 
 
 pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                     search_type: SearchType, namespace: Namespace,
-                    session: &core::Session) -> vec::IntoIter<Match> {
+                    session: SessionRef) -> vec::IntoIter<Match> {
     debug!("resolve_path {:?} {:?} {} {:?}", path, filepath.to_str(), pos, search_type);
     let len = path.segments.len();
     if len == 1 {
@@ -987,7 +987,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
 }
 
 pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_type: SearchType, namespace: Namespace,
-                          session: &core::Session) -> vec::IntoIter<Match> {
+                          session: SessionRef) -> vec::IntoIter<Match> {
     debug!("do_external_search path {:?} {:?}", path, filepath.to_str());
     let mut out = Vec::new();
     if path.len() == 1 {
@@ -1048,7 +1048,7 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
 }
 
 pub fn search_for_field_or_method(context: Match, searchstr: &str, search_type: SearchType,
-                                  session: &core::Session) -> vec::IntoIter<Match> {
+                                  session: SessionRef) -> vec::IntoIter<Match> {
     let m = context;
     let mut out = Vec::new();
     match m.mtype {

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -1,5 +1,5 @@
 use {core, ast, codecleaner, codeiter, typeinf, util};
-use core::Session;
+use core::SessionRef;
 
 use std::iter::Iterator;
 use std::path::Path;
@@ -289,11 +289,10 @@ pub fn point_to_coords(src: &str, point: usize) -> (usize, usize) {
     (nlines, point - linestart)
 }
 
-pub fn point_to_coords_from_file(path: &Path, point: usize, session: &Session) -> Option<(usize, usize)> {
+pub fn point_to_coords_from_file(path: &Path, point: usize, session: SessionRef) -> Option<(usize, usize)> {
     let mut lineno = 0;
     let mut p = 0;
-    for line_r in session.load_file(path).lines() {
-        let line = line_r;
+    for line in session.load_file(path).lines() {
         lineno += 1;
         if point < (p + line.len()) {
             return Some((lineno, point - p));

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -1,11 +1,10 @@
 use ast::with_error_checking_parse;
-use core;
-use core::{Match, MatchType};
+use core::{Match, MatchType, SessionRef};
 use typeinf::get_function_declaration;
 
 use syntex_syntax::ast::ImplItem_;
 
-pub fn snippet_for_match(m: &Match, session: &core::Session) -> String {
+pub fn snippet_for_match(m: &Match, session: SessionRef) -> String {
     match m.mtype {
         MatchType::Function => {
             let method = get_function_declaration(&m, session);
@@ -20,8 +19,8 @@ pub fn snippet_for_match(m: &Match, session: &core::Session) -> String {
 }
 
 struct MethodInfo {
-    name : String,
-    args : Vec<String>
+    name: String,
+    args: Vec<String>
 }
 
 impl MethodInfo {

--- a/src/racer/testutils.rs
+++ b/src/racer/testutils.rs
@@ -18,3 +18,13 @@ pub fn rejustify(src: &str) -> String {
 pub fn slice(src: &str, (begin, end): (usize, usize)) -> &str {
     &src[begin..end]
 }
+
+#[macro_export]
+macro_rules! test_source {
+    (rejustify $e:expr) => {
+        $crate::core::new_source(rejustify($e))
+    };
+    ($e:expr) => {
+        $crate::core::new_source(String::from($e))
+    };
+}

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -1,7 +1,7 @@
 // Type inference
 
-use core::{Match, Scope, SessionRef};
-use nameres::{resolve_path_with_str};
+use core::{Match, Src, SessionRef, Scope};
+use nameres::resolve_path_with_str;
 use core::Namespace::TypeNamespace;
 use core;
 use ast;
@@ -43,13 +43,13 @@ fn generates_skeleton_for_mod() {
     assert_eq!("mod foo {};", out);
 }
 
-fn get_type_of_self_arg(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
+fn get_type_of_self_arg(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     debug!("get_type_of_self_arg {:?}", m);
     scopes::find_impl_start(msrc, m.point, 0).and_then(|start| {
-        let decl = generate_skeleton_for_parsing(&msrc[start..]);
+        let decl = generate_skeleton_for_parsing(&msrc.from(start));
         debug!("get_type_of_self_arg impl skeleton |{}|", decl);
 
-        if (&decl).starts_with("impl") {
+        if decl.starts_with("impl") {
             let implres = ast::parse_impl(decl);
             debug!("get_type_of_self_arg implres |{:?}|", implres);
             resolve_path_with_str(&implres.name_path.expect("failed parsing impl name"),
@@ -73,13 +73,13 @@ fn get_type_of_self_arg(m: &Match, msrc: &str, session: SessionRef) -> Option<co
     })
 }
 
-fn get_type_of_fnarg(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
+fn get_type_of_fnarg(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     if m.matchstr == "self" {
         return get_type_of_self_arg(m, msrc, session);
     }
 
     let stmtstart = scopes::find_stmt_start(msrc, m.point).unwrap();
-    let block = &msrc[stmtstart..];
+    let block = msrc.from(stmtstart);
     if let Some((start, end)) = codeiter::iter_stmts(block).next() {
         let blob = &msrc[(stmtstart+start)..(stmtstart+end)];
         // wrap in "impl blah { }" so that methods get parsed correctly too
@@ -94,10 +94,10 @@ fn get_type_of_fnarg(m: &Match, msrc: &str, session: SessionRef) -> Option<core:
     None
 }
 
-fn get_type_of_let_expr(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
+fn get_type_of_let_expr(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     // ASSUMPTION: this is being called on a let decl
     let point = scopes::find_stmt_start(msrc, m.point).unwrap();
-    let src = &msrc[point..];
+    let src = msrc.from(point);
 
     if let Some((start, end)) = codeiter::iter_stmts(src).next() {
         let blob = &src[start..end];
@@ -111,15 +111,14 @@ fn get_type_of_let_expr(m: &Match, msrc: &str, session: SessionRef) -> Option<co
     }
 }
 
-fn get_type_of_if_let_expr(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
+fn get_type_of_if_let_expr(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     // ASSUMPTION: this is being called on an if let decl
     let stmtstart = scopes::find_stmt_start(msrc, m.point).unwrap();
-    let stmt = &msrc[stmtstart..];
+    let stmt = msrc.from(stmtstart);
     let point = stmt.find("if let").unwrap();
-    let src = &stmt[point..];
-    let src = generate_skeleton_for_parsing(src);
+    let src = core::new_source(generate_skeleton_for_parsing(&stmt[point..]));
 
-    if let Some((start, end)) = codeiter::iter_stmts(&src).next() {
+    if let Some((start, end)) = codeiter::iter_stmts(src.as_ref()).next() {
         let blob = &src[start..end];
         debug!("get_type_of_if_let_expr calling parse_if_let |{}|", blob);
 
@@ -136,7 +135,7 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: Sess
 
     let src = session.load_file(&structmatch.filepath);
 
-    let opoint = scopes::find_stmt_start(&src, structmatch.point);
+    let opoint = scopes::find_stmt_start(src, structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
 
     let fields = ast::parse_struct_fields(structsrc.to_owned(), Scope::from_match(structmatch));
@@ -159,8 +158,8 @@ pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match, session: S
         "struct ".to_owned() + &src[structmatch.point..(to+1)] + ";"
     } else {
         assert!(structmatch.mtype == core::MatchType::Struct);
-        let opoint = scopes::find_stmt_start(&src, structmatch.point);
-        get_first_stmt(&src[opoint.unwrap()..]).to_owned()
+        let opoint = scopes::find_stmt_start(src, structmatch.point);
+        (*get_first_stmt(src.from(opoint.unwrap()))).to_owned()
     };
 
     debug!("get_tuplestruct_field_type structsrc=|{}|", structsrc);
@@ -176,14 +175,14 @@ pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match, session: S
     None
 }
 
-pub fn get_first_stmt(src: &str) -> &str {
+pub fn get_first_stmt(src: Src) -> Src {
     match codeiter::iter_stmts(src).next() {
-        Some((from, to)) => &src[from..to],
+        Some((from, to)) => src.from_to(from, to),
         None => src
     }
 }
 
-pub fn get_type_of_match(m: Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
+pub fn get_type_of_match(m: Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     debug!("get_type_of match {:?} ", m);
 
     match m.mtype {
@@ -203,7 +202,7 @@ macro_rules! otry {
     ($e:expr) => (match $e { Some(e) => e, None => return None })
 }
 
-pub fn get_type_from_match_arm(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
+pub fn get_type_from_match_arm(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     // We construct a faux match stmt and then parse it. This is because the
     // match stmt may be incomplete (half written) in the real code
 
@@ -216,7 +215,7 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str, session: SessionRef) -> Op
     let preblock = &msrc[stmtstart..scopestart];
     let matchstart = otry!(util::find_last_str("match ", preblock)) + stmtstart;
 
-    let lhs_start = scopes::get_start_of_pattern(msrc, arm);
+    let lhs_start = scopes::get_start_of_pattern(&msrc, arm);
     let lhs = &msrc[lhs_start..arm];
     // construct faux match statement and recreate point
     let mut fauxmatchstmt = (&msrc[matchstart..scopestart]).to_owned();
@@ -237,14 +236,14 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str, session: SessionRef) -> Op
 
 pub fn get_function_declaration(fnmatch: &Match, session: SessionRef) -> String {
     let src = session.load_file(&fnmatch.filepath);
-    let start = scopes::find_stmt_start(&src, fnmatch.point).unwrap();
+    let start = scopes::find_stmt_start(src, fnmatch.point).unwrap();
     let end = (&src[start..]).find('{').unwrap();
     (&src[start..end+start]).to_owned()
 }
 
 pub fn get_return_type_of_function(fnmatch: &Match, session: SessionRef) -> Option<core::Ty> {
     let src = session.load_file(&fnmatch.filepath);
-    let point = scopes::find_stmt_start(&src, fnmatch.point).unwrap();
+    let point = scopes::find_stmt_start(src, fnmatch.point).unwrap();
     (&src[point..]).find("{").and_then(|n| {
         // wrap in "impl blah { }" so that methods get parsed correctly too
         let mut decl = String::new();

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -1,6 +1,6 @@
 // Type inference
 
-use core::Match;
+use core::{Match, Scope, SessionRef};
 use nameres::{resolve_path_with_str};
 use core::Namespace::TypeNamespace;
 use core;
@@ -43,7 +43,7 @@ fn generates_skeleton_for_mod() {
     assert_eq!("mod foo {};", out);
 }
 
-fn get_type_of_self_arg(m: &Match, msrc: &str, session: &core::Session) -> Option<core::Ty> {
+fn get_type_of_self_arg(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
     debug!("get_type_of_self_arg {:?}", m);
     scopes::find_impl_start(msrc, m.point, 0).and_then(|start| {
         let decl = generate_skeleton_for_parsing(&msrc[start..]);
@@ -73,7 +73,7 @@ fn get_type_of_self_arg(m: &Match, msrc: &str, session: &core::Session) -> Optio
     })
 }
 
-fn get_type_of_fnarg(m: &Match, msrc: &str, session: &core::Session) -> Option<core::Ty> {
+fn get_type_of_fnarg(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
     if m.matchstr == "self" {
         return get_type_of_self_arg(m, msrc, session);
     }
@@ -89,12 +89,12 @@ fn get_type_of_fnarg(m: &Match, msrc: &str, session: &core::Session) -> Option<c
         s.push_str(&blob[..(find_start_of_function_body(blob)+1)]);
         s.push_str("}}");
         let argpos = m.point - (stmtstart+start) + impl_header_len;
-        return ast::parse_fn_arg_type(s, argpos, core::Scope::from_match(m), session);
+        return ast::parse_fn_arg_type(s, argpos, Scope::from_match(m), session);
     }
     None
 }
 
-fn get_type_of_let_expr(m: &Match, msrc: &str, session: &core::Session) -> Option<core::Ty> {
+fn get_type_of_let_expr(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
     // ASSUMPTION: this is being called on a let decl
     let point = scopes::find_stmt_start(msrc, m.point).unwrap();
     let src = &msrc[point..];
@@ -104,14 +104,14 @@ fn get_type_of_let_expr(m: &Match, msrc: &str, session: &core::Session) -> Optio
         debug!("get_type_of_let_expr calling parse_let |{}|", blob);
 
         let pos = m.point - point - start;
-        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point };
+        let scope = Scope{ filepath: m.filepath.clone(), point: m.point };
         ast::get_let_type(blob.to_owned(), pos, scope, session)
     } else {
         None
     }
 }
 
-fn get_type_of_if_let_expr(m: &Match, msrc: &str, session: &core::Session) -> Option<core::Ty> {
+fn get_type_of_if_let_expr(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
     // ASSUMPTION: this is being called on an if let decl
     let stmtstart = scopes::find_stmt_start(msrc, m.point).unwrap();
     let stmt = &msrc[stmtstart..];
@@ -124,14 +124,14 @@ fn get_type_of_if_let_expr(m: &Match, msrc: &str, session: &core::Session) -> Op
         debug!("get_type_of_if_let_expr calling parse_if_let |{}|", blob);
 
         let pos = m.point - stmtstart - point - start;
-        let scope = core::Scope{ filepath: m.filepath.clone(), point: m.point };
+        let scope = Scope{ filepath: m.filepath.clone(), point: m.point };
         ast::get_let_type(blob.to_owned(), pos, scope, session)
     } else {
         None
     }
 }
 
-pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: &core::Session) -> Option<core::Ty> {
+pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: SessionRef) -> Option<core::Ty> {
     assert!(structmatch.mtype == core::MatchType::Struct);
 
     let src = session.load_file(&structmatch.filepath);
@@ -139,7 +139,7 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: &cor
     let opoint = scopes::find_stmt_start(&src, structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
 
-    let fields = ast::parse_struct_fields(structsrc.to_owned(), core::Scope::from_match(structmatch));
+    let fields = ast::parse_struct_fields(structsrc.to_owned(), Scope::from_match(structmatch));
     for (field, _, ty) in fields.into_iter() {
         if fieldname == field {
             return ty;
@@ -148,7 +148,7 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: &cor
     None
 }
 
-pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match, session: &core::Session) -> Option<core::Ty> {
+pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match, session: SessionRef) -> Option<core::Ty> {
     let src = session.load_file(&structmatch.filepath);
 
     let structsrc = if let core::MatchType::EnumVariant = structmatch.mtype {
@@ -165,7 +165,7 @@ pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match, session: &
 
     debug!("get_tuplestruct_field_type structsrc=|{}|", structsrc);
 
-    let fields = ast::parse_struct_fields(structsrc, core::Scope::from_match(structmatch));
+    let fields = ast::parse_struct_fields(structsrc, Scope::from_match(structmatch));
     let mut i = 0u32;
     for (_, _, ty) in fields.into_iter() {
         if i == fieldnum {
@@ -183,7 +183,7 @@ pub fn get_first_stmt(src: &str) -> &str {
     }
 }
 
-pub fn get_type_of_match(m: Match, msrc: &str, session: &core::Session) -> Option<core::Ty> {
+pub fn get_type_of_match(m: Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
     debug!("get_type_of match {:?} ", m);
 
     match m.mtype {
@@ -203,7 +203,7 @@ macro_rules! otry {
     ($e:expr) => (match $e { Some(e) => e, None => return None })
 }
 
-pub fn get_type_from_match_arm(m: &Match, msrc: &str, session: &core::Session) -> Option<core::Ty> {
+pub fn get_type_from_match_arm(m: &Match, msrc: &str, session: SessionRef) -> Option<core::Ty> {
     // We construct a faux match stmt and then parse it. This is because the
     // match stmt may be incomplete (half written) in the real code
 
@@ -229,20 +229,20 @@ pub fn get_type_from_match_arm(m: &Match, msrc: &str, session: &core::Session) -
     ast::get_match_arm_type(fauxmatchstmt, faux_point,
                             // scope is used to locate expression, so send
                             // it the start of the match expr
-                            core::Scope {
+                            Scope {
                                 filepath: m.filepath.clone(),
                                 point: matchstart,
                             }, session)
 }
 
-pub fn get_function_declaration(fnmatch: &Match, session: &core::Session) -> String {
+pub fn get_function_declaration(fnmatch: &Match, session: SessionRef) -> String {
     let src = session.load_file(&fnmatch.filepath);
     let start = scopes::find_stmt_start(&src, fnmatch.point).unwrap();
     let end = (&src[start..]).find('{').unwrap();
     (&src[start..end+start]).to_owned()
 }
 
-pub fn get_return_type_of_function(fnmatch: &Match, session: &core::Session) -> Option<core::Ty> {
+pub fn get_return_type_of_function(fnmatch: &Match, session: SessionRef) -> Option<core::Ty> {
     let src = session.load_file(&fnmatch.filepath);
     let point = scopes::find_stmt_start(&src, fnmatch.point).unwrap();
     (&src[point..]).find("{").and_then(|n| {
@@ -252,6 +252,6 @@ pub fn get_return_type_of_function(fnmatch: &Match, session: &core::Session) -> 
         decl.push_str(&src[point..(point+n+1)]);
         decl.push_str("}}");
         debug!("get_return_type_of_function: passing in |{}|", decl);
-        ast::parse_fn_output(decl, core::Scope::from_match(fnmatch))
+        ast::parse_fn_output(decl, Scope::from_match(fnmatch))
     })
 }

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -1,24 +1,16 @@
 // Small functions of utility
 
 use core::SearchType::{self, ExactMatch, StartsWith};
-use core::Session;
+use core::SessionRef;
 use std;
 use std::cmp;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-pub fn getline(filepath: &Path, linenum: usize, session: &Session) -> String {
-    let mut i = 0;
-    let file = BufReader::new(session.open_file(filepath).unwrap());
-    for line in file.lines() {
-        //print!("{}", line);
-        i += 1;
-        if i == linenum {
-            return line.unwrap();
-        }
-    }
-    "not found".into()
+pub fn getline(filepath: &Path, linenum: usize, session: SessionRef) -> String {
+    let reader = BufReader::new(session.open_file(filepath).unwrap());
+    reader.lines().nth(linenum - 1).unwrap_or(Ok("not found".into())).unwrap()
 }
 
 pub fn is_pattern_char(c: char) -> bool {
@@ -144,10 +136,6 @@ fn find_ident_end_ascii() {
 fn find_ident_end_unicode() {
     assert_eq!(7, find_ident_end("num_µs", 0));
     assert_eq!(10, find_ident_end("ends_in_µ", 0));
-}
-
-pub fn to_refs(v: &Vec<String>) -> Vec<&str> {
-    v.iter().map(|s| s.as_ref()).collect()
 }
 
 pub fn find_last_str(needle: &str, mut haystack: &str) -> Option<usize> {


### PR DESCRIPTION
The `codecleaner` iterator yields indices that don't change as long as this source lives. Now that we cache the source, we can also calculate these indices only once and cache them together with the source.

(Unfortunately this is not easily extended to `iter_stmts` because the results from there depend on which point the iteration starts. A more complicated data structure would be needed for that.)

Added a dependency on the `typed-arena` crate. The arena allows us to cache strings/IndexedSource objects and still get long lived references out of the RefCells.

This gives a ~33% speedup in the usual benchmark, 9.7 to 6.6 ms.