### PR TITLE
nameres: fix matching of trait-impl methods (fixes #349)

### DIFF
--- a/tests/system.rs
+++ b/tests/system.rs
@@ -96,6 +96,42 @@ fn main() {
 }
 
 #[test]
+fn completes_trait_methods() {
+    let src = "
+mod sub {
+    pub trait Trait {
+        fn traitf() -> bool;
+        fn traitm(&self) -> bool;
+    }
+
+    pub struct Foo(bool);
+
+    impl Trait for Foo {
+        fn traitf() -> bool { false }
+        fn traitm(&self) -> bool { true }
+    }
+}
+
+fn main() { // l16
+    let t = sub::Foo(true);
+    sub::Foo::
+    t.t
+}
+";
+    let path = tmpname();
+    write_file(&path, src);
+    let pos1 = scopes::coords_to_point(src, 18, 14);  // sub::Foo::
+    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&path, &path)).nth(0);
+    let pos2 = scopes::coords_to_point(src, 19, 7);   // t.t
+    let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&path, &path)).nth(0);
+    fs::remove_file(&path).unwrap();
+    println!("{:?}", got1);
+    println!("{:?}", got2);
+    assert_eq!(got1.unwrap().matchstr, "traitf".to_string());
+    assert_eq!(got2.unwrap().matchstr, "traitm".to_string());
+}
+
+#[test]
 fn follows_use() {
     let src2="
     pub fn myfn() {}


### PR DESCRIPTION
Methods in trait impls are never declared "pub", but still visible
outside their module.