### PR TITLE
Implement name lookup for more loop headers

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -118,6 +118,8 @@ impl<'v> visit::Visitor<'v> for PatBindVisitor {
         // don't visit the RHS or block of an 'if let' or 'for' stmt
         if let ast::ExprIfLet(ref pattern, _,_,_) = ex.node {
             self.visit_pat(pattern);
+        } else if let ast::ExprWhileLet(ref pattern, _,_,_) = ex.node {
+            self.visit_pat(pattern);
         } else if let ast::ExprForLoop(ref pattern, _, _, _) = ex.node {
             self.visit_pat(pattern);
         } else {
@@ -265,15 +267,19 @@ struct LetTypeVisitor<'s> {
 
 impl<'s, 'v> visit::Visitor<'v> for LetTypeVisitor<'s> {
     fn visit_expr(&mut self, ex: &'v ast::Expr) {
-        if let ast::ExprIfLet(ref pattern, ref expr, _, _) = ex.node {
-            let mut v = ExprTypeVisitor{ scope: self.scope.clone(), result: None,
-                                         session: self.session };
-            v.visit_expr(expr);
-            self.result = v.result.and_then(|ty|
-                   destructure_pattern_to_ty(pattern, self.pos, &ty, &self.scope, self.session))
-                .and_then(|ty| path_to_match(ty, self.session));
-        } else {
-            visit::walk_expr(self, ex)
+        match ex.node {
+            ast::ExprIfLet(ref pattern, ref expr, _, _) |
+            ast::ExprWhileLet(ref pattern, ref expr, _, _) => {
+                let mut v = ExprTypeVisitor{ scope: self.scope.clone(), result: None,
+                                             session: self.session };
+                v.visit_expr(expr);
+                self.result = v.result.and_then(|ty|
+                       destructure_pattern_to_ty(pattern, self.pos, &ty, &self.scope, self.session))
+                    .and_then(|ty| path_to_match(ty, self.session));
+            }
+            _ => {
+                visit::walk_expr(self, ex)
+            }
         }
     }
 

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -25,6 +25,7 @@ pub enum MatchType {
     Crate,
     Let,
     IfLet,
+    For,
     StructField,
     Impl,
     Enum,

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -25,6 +25,7 @@ pub enum MatchType {
     Crate,
     Let,
     IfLet,
+    WhileLet,
     For,
     StructField,
     Impl,

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -4,7 +4,7 @@ use util::{symbol_matches, txt_matches, find_ident_end, is_ident_char, char_at};
 use nameres::{get_module_file, get_crate_file, resolve_path};
 use core::SearchType::{self, StartsWith, ExactMatch};
 use core::MatchType::{self, Let, Module, Function, Struct, Type, Trait, Enum, EnumVariant,
-                      Const, Static, IfLet, For};
+                      Const, Static, IfLet, WhileLet, For};
 use core::Namespace::BothNamespaces;
 use std::cell::Cell;
 use std::path::Path;
@@ -166,6 +166,13 @@ pub fn match_if_let(msrc: &str, blobstart: usize, blobend: usize,
                     local: bool) -> Vec<Match> {
     match_pattern_let(msrc, blobstart, blobend, searchstr, filepath,
                       search_type, local, "if let ", IfLet)
+}
+
+pub fn match_while_let(msrc: &str, blobstart: usize, blobend: usize,
+                 searchstr: &str, filepath: &Path, search_type: SearchType,
+                 local: bool) -> Vec<Match> {
+    match_pattern_let(msrc, blobstart, blobend, searchstr, filepath,
+                      search_type, local, "while let ", WhileLet)
 }
 
 pub fn match_let(msrc: &str, blobstart: usize, blobend: usize,

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1,6 +1,6 @@
 // Name resolution
 
-use {core, ast, codeiter, matchers, scopes, typeinf, util};
+use {core, ast, codeiter, matchers, scopes, typeinf};
 use core::SearchType::{self, ExactMatch, StartsWith};
 use core::{Match, Src, SessionRef};
 use core::MatchType::{Module, Function, Struct, Enum, FnArg, Trait, StructField, Impl, MatchArm};
@@ -179,7 +179,18 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &
                 }
                 return out.into_iter();
             }
-        } else if let Some(n) = util::find_last_str("match ", preblock) {
+        } else if let Some(n) = preblock.rfind("for ") {
+            let forstart = stmtstart + n;
+            let src = (&msrc[forstart..scopestart+1]).to_owned() + "}";
+            if txt_matches(search_type, searchstr, &msrc[forstart..scopestart]) {
+                let mut out = matchers::match_for(&src, 0, src.len(), searchstr,
+                                                  filepath, search_type, true);
+                for m in &mut out {
+                    m.point += forstart;
+                }
+                return out.into_iter();
+            }
+        } else if let Some(n) = preblock.rfind("match ") {
             // TODO: this code is crufty. refactor me!
             let matchstart = stmtstart + n;
             let matchstmt = typeinf::get_first_stmt(msrc.from(matchstart));

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -179,6 +179,17 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &
                 }
                 return out.into_iter();
             }
+        } else if let Some(n) = preblock.find("while let") {
+            let whileletstart = stmtstart + n;
+            let src = (&msrc[whileletstart..scopestart+1]).to_owned() + "}";
+            if txt_matches(search_type, searchstr, &src) {
+                let mut out = matchers::match_while_let(&src, 0, src.len(), searchstr,
+                                                        filepath, search_type, true);
+                for m in &mut out {
+                    m.point += whileletstart;
+                }
+                return out.into_iter();
+            }
         } else if let Some(n) = preblock.rfind("for ") {
             let forstart = stmtstart + n;
             let src = (&msrc[forstart..scopestart+1]).to_owned() + "}";

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -138,15 +138,6 @@ fn find_ident_end_unicode() {
     assert_eq!(10, find_ident_end("ends_in_µ", 0));
 }
 
-pub fn find_last_str(needle: &str, mut haystack: &str) -> Option<usize> {
-    let mut res = None;
-    while let Some(n) = haystack.find(needle) {
-        res = Some(n);
-        haystack = &haystack[n+1..];
-    }
-    res
-}
-
 // PD: short term replacement for .char_at() function. Should be replaced once
 // that stabilizes
 pub fn char_at(src: &str, i: usize) -> char {


### PR DESCRIPTION
This implements name (and type) lookup for more loop headers, i.e. `for-in` and `while let`.