### PR TITLE
fixes for #381 (const functions)

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -164,7 +164,7 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &
         let preblock = &msrc[stmtstart..scopestart];
         debug!("PHIL search_scope_headers preblock is |{}|", preblock);
 
-        if preblock.starts_with("fn") || preblock.starts_with("pub fn") {
+        if preblock.starts_with("fn") || preblock.starts_with("pub fn") || preblock.starts_with("pub const fn") {
             return search_fn_args(stmtstart, scopestart, &msrc, searchstr, filepath, search_type, true);
 
         // 'if let' can be an expression, so might not be at the start of the stmt

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -62,6 +62,23 @@ fn completes_pub_fn_locally() {
 }
 
 #[test]
+fn completes_pub_const_fn_locally() {
+    let src="
+    pub const fn apple() {
+    }
+
+    fn main() {
+        let b = ap
+    }";
+    let path = tmpname();
+    write_file(&path, src);
+    let pos = scopes::coords_to_point(src, 6, 18);
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    fs::remove_file(&path).unwrap();
+    assert_eq!("apple".to_string(), got.matchstr.to_string());
+}
+
+#[test]
 fn completes_local_scope_let() {
     let src="
     fn main() {


### PR DESCRIPTION
Trying to fix #381. Digging through some Rust source I found out that there can be functions with `const` keyword also. Racer thinks that this is a constant instead of a function and this messes up the parsing. Maybe this is a hack, but you can reject this if it is :)