### PR TITLE
Vim: Add #342, gD acts like gd in new vsplit

### DIFF
--- a/plugin/racer.vim
+++ b/plugin/racer.vim
@@ -5,6 +5,7 @@
 " 2. copy this file into .vim/plugin/
 " 3. - now in insert mode do 'C-x C-o' to autocomplete the thing at the cursor
 "    - in normal mode do 'gd' to go to definition
+"    - 'gD' goes to the definition in a new vertical split
 "
 " (This plugin is best used with the 'hidden' option enabled so that switching buffers doesn't force you to save) 
 
@@ -177,6 +178,7 @@ endfunction
 
 autocmd FileType rust setlocal omnifunc=RacerComplete
 autocmd FileType rust nnoremap gd :call RacerGoToDefinition()<cr>
+autocmd FileType rust nnoremap gD :vsplit<cr>:call RacerGoToDefinition()<cr>
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
This adds the feature of being able to use gD to open the definition in a new vertical split, as requested in #342.