### PR TITLE
uses clap to parse command line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "racer"
 version = "1.0.0"
 dependencies = [
+ "clap 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -18,9 +19,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "env_logger"
@@ -82,6 +99,11 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syntex_syntax"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +141,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ syntex_syntax = "*"
 toml = "*"
 env_logger = "*"
 typed-arena = "*"
+clap = "~1.5.3"
 
 [features]
 nightly = []


### PR DESCRIPTION
A possible implementation for #326 which doesn't sacrifice any performance, but gains a good bit in the command line user-friendliness department...at least IMO :wink: This PR would also make it  easier to add functionality to the command line in the future (such as possibly dealing with multiple rust sources as [mentioned recently](https://www.reddit.com/r/rust/comments/3thorf/multirust_and_racervim_dont_play_nice_together/) in [/r/rust](https://reddit.com/r/rust))

Something to note, this PR uses a slightly hacky way to stay 100% compatible with previous `racer` command line binaries. Specifically that one could do either:

```
$ racer complete <fqn>
$ racer complete <linenum> <charnum> <fn_name> [substitute_file]
```

The first argument to the `complete` command has a dual purpose. If 100% backwards compatibility isn't desired, there may be a more clean way to solve this. Having said that, the way this PR implements it works just fine, and to the user, there is no difference from previous releases.

A final note, I have run some simple tests, using this branch as my main `racer` for personal development for a little bit to work out any bugs, but I don't know how much of the full functionality I've actually tested. So if there are formal tests (beyond `cargo test`) I'd recommend running them against this branch just to check.