### PR TITLE
Fix Offsets of CRLF files

### DIFF
--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -269,7 +269,7 @@ pub fn end_of_next_scope(src: &str) -> &str {
 
 pub fn coords_to_point(src: &str, mut linenum: usize, col: usize) -> usize {
     let mut point = 0;
-    for line in src.lines() {
+    for line in src.split('\n') {
         linenum -= 1;
         if linenum == 0 { break }
         point += line.len() + 1;  // +1 for the \n
@@ -294,7 +294,7 @@ pub fn point_to_coords(src: &str, point: usize) -> (usize, usize) {
 pub fn point_to_coords_from_file(path: &Path, point: usize, session: SessionRef) -> Option<(usize, usize)> {
     let mut lineno = 0;
     let mut p = 0;
-    for line in session.load_file(path).lines() {
+    for line in session.load_file(path).split('\n') {
         lineno += 1;
         if point < (p + line.len()) {
             return Some((lineno, point - p));


### PR DESCRIPTION
``coords_to_point`` and ``point_to_coords_from_file`` assume that the line endings are ending with a simple ``LF`` and not a ``CRLF``, which is why they get the offset wrong which then causes Racer to complete the wrong parts of the code. By using ``split('\n')`` instead of ``lines()``, the code can still assume that the ``LF`` is missing, but the ``CR`` is still part of the individual splits, so it gets counted properly.

Fixes #435, Fixes #434, Fixes #424. I suspect this might fix some of the other issues people are having on Windows too.