### PR TITLE
Update README.md for Rust 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### With `cargo install`
 
-This method currently requires a beta or nightly install of Rust. Simply run:
+This method requires Rust 1.5. Simply run:
 
 ```cargo install --git 'https://github.com/phildawes/racer.git'```
 


### PR DESCRIPTION
As of Rust 1.5, cargo install is in the stable build