### PR TITLE
Add support for caching in-memory buffers to FileCache

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -122,7 +122,8 @@ fn run_the_complete_fn(cfg: &Config, print_type: CompletePrinter) {
     let fn_path = &*cfg.fn_name.as_ref().unwrap();
     let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
 
-    let session = core::Session::from_path(fn_path, substitute_file);
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, fn_path, substitute_file);
     let src = session.load_file(fn_path);
     let line = &getline(substitute_file, cfg.linenum, &session);
     let (start, pos) = util::expand_ident(line, cfg.charnum);
@@ -149,7 +150,8 @@ fn external_complete(cfg: Config) {
     // input: a command line string passed in
     let p: Vec<&str> = cfg.fqn.as_ref().unwrap().split("::").collect();
     let cwd = Path::new(".");
-    let session = core::Session::from_path(&cwd, &cwd);
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &cwd, &cwd);
 
     for m in do_file_search(p[0], &Path::new(".")) {
         if p.len() == 1 {
@@ -167,7 +169,8 @@ fn external_complete(cfg: Config) {
 #[cfg(not(test))]
 fn prefix(cfg: Config) {
     let fn_path = &*cfg.fn_name.as_ref().unwrap();
-    let session = core::Session::from_path(fn_path, cfg.substitute_file.as_ref().unwrap_or(fn_path));
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, fn_path, cfg.substitute_file.as_ref().unwrap_or(fn_path));
 
     // print the start, end, and the identifier prefix being matched
     let line = &getline(fn_path, cfg.linenum, &session);
@@ -183,7 +186,8 @@ fn prefix(cfg: Config) {
 #[cfg(not(test))]
 fn find_definition(cfg: Config) {
     let fn_path = &*cfg.fn_name.as_ref().unwrap();
-    let session = core::Session::from_path(fn_path, cfg.substitute_file.as_ref().unwrap_or(fn_path));
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, fn_path, cfg.substitute_file.as_ref().unwrap_or(fn_path));
     let src = session.load_file(fn_path);
     let pos = scopes::coords_to_point(&src, cfg.linenum, cfg.charnum);
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 #[cfg(not(test))]
-fn match_with_snippet_fn(m: Match, session: core::SessionRef, interface: Interface) {
+fn match_with_snippet_fn(m: Match, session: &core::Session, interface: Interface) {
     let (linenum, charnum) = scopes::point_to_coords_from_file(&m.filepath, m.point, session).unwrap();
     if m.matchstr == "" {
         panic!("MATCHSTR is empty - waddup?");
@@ -57,7 +57,7 @@ fn match_with_snippet_fn(m: Match, session: core::SessionRef, interface: Interfa
 }
 
 #[cfg(not(test))]
-fn match_fn(m: Match, session: core::SessionRef, interface: Interface) {
+fn match_fn(m: Match, session: &core::Session, interface: Interface) {
     if let Some((linenum, charnum)) = scopes::point_to_coords_from_file(&m.filepath,
                                                                         m.point,
                                                                         session) {

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -256,15 +256,15 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
     }
 }
 
-struct LetTypeVisitor<'s> {
+struct LetTypeVisitor<'s: 'r, 'r> {
     scope: Scope,
-    session: SessionRef<'s>,
+    session: SessionRef<'s, 'r>,
     srctxt: String,
     pos: usize,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
 }
 
-impl<'s, 'v> visit::Visitor<'v> for LetTypeVisitor<'s> {
+impl<'s, 'r, 'v> visit::Visitor<'v> for LetTypeVisitor<'s, 'r> {
     fn visit_expr(&mut self, ex: &'v ast::Expr) {
         match ex.node {
             ast::ExprIfLet(ref pattern, ref expr, _, _) |
@@ -306,14 +306,14 @@ impl<'s, 'v> visit::Visitor<'v> for LetTypeVisitor<'s> {
     }
 }
 
-struct MatchTypeVisitor<'s> {
+struct MatchTypeVisitor<'s: 'r, 'r> {
     scope: Scope,
-    session: SessionRef<'s>,
+    session: SessionRef<'s, 'r>,
     pos: usize,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
 }
 
-impl<'s, 'v> visit::Visitor<'v> for MatchTypeVisitor<'s> {
+impl<'s, 'r, 'v> visit::Visitor<'v> for MatchTypeVisitor<'s, 'r> {
     fn visit_expr(&mut self, ex: &'v ast::Expr) {
         if let ast::ExprMatch(ref subexpression, ref arms) = ex.node {
             debug!("PHIL sub expr is {:?}", subexpression);
@@ -434,13 +434,13 @@ fn get_type_of_typedef(m: Match, session: SessionRef) -> Option<Match> {
 }
 
 
-struct ExprTypeVisitor<'s> {
+struct ExprTypeVisitor<'s: 'r, 'r> {
     scope: Scope,
-    session: SessionRef<'s>,
+    session: SessionRef<'s, 'r>,
     result: Option<Ty>,
 }
 
-impl<'s, 'v> visit::Visitor<'v> for ExprTypeVisitor<'s> {
+impl<'s, 'r, 'v> visit::Visitor<'v> for ExprTypeVisitor<'s, 'r> {
     fn visit_expr(&mut self, expr: &ast::Expr) {
         debug!("visit_expr {:?}", expr);
         //walk_expr(self, ex, e)
@@ -998,14 +998,14 @@ impl<'v> visit::Visitor<'v> for FnOutputVisitor {
     }
 }
 
-pub struct FnArgTypeVisitor<'s> {
+pub struct FnArgTypeVisitor<'s: 'r, 'r> {
     argpos: usize,
     scope: Scope,
-    session: SessionRef<'s>,
+    session: SessionRef<'s, 'r>,
     pub result: Option<Ty>
 }
 
-impl<'s, 'v> visit::Visitor<'v> for FnArgTypeVisitor<'s> {
+impl<'s, 'r, 'v> visit::Visitor<'v> for FnArgTypeVisitor<'s, 'r> {
     fn visit_fn(&mut self, _: visit::FnKind, fd: &ast::FnDecl, _: &ast::Block, _: codemap::Span, _: ast::NodeId) {
         for arg in &fd.inputs {
             let codemap::BytePos(lo) = arg.pat.span.lo;

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -354,7 +354,7 @@ pub struct Session<'s> {
     cache: &'s FileCache<'s>              // cache for file contents
 }
 
-pub type SessionRef<'s> = &'s Session<'s>;
+pub type SessionRef<'s, 'r> = &'r Session<'s>;
 
 impl<'s> fmt::Debug for Session<'s> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -406,6 +406,19 @@ impl<'s> Session<'s> {
         }).as_ref()
     }
 
+    /// Cache the contents of `buf` using the given `Path` for a key.
+    ///
+    /// Subsequent calls to load_file will return an IndexedSource of the provided buf.
+    pub fn cache_file_contents<T>(&'s self, filepath: &path::Path, buf: T) -> Src<'s>
+    where T: Into<String> {
+        let mut cache = self.cache.raw_map.borrow_mut();
+        cache.insert(filepath.to_path_buf(), {
+            self.cache.arena.alloc(IndexedSource::new(buf.into()))
+        });
+
+        cache.get(&filepath.to_path_buf()).unwrap().as_ref()
+    }
+
     pub fn load_file_and_mask_comments(&'s self, filepath: &path::Path) -> Src<'s> {
         let mut cache = self.cache.masked_map.borrow_mut();
         cache.entry(filepath.to_path_buf()).or_insert_with(|| {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -497,6 +497,12 @@ pub struct Session<'c> {
 }
 
 
+impl<'a> Drop for Session<'a> {
+    fn drop(&mut self) {
+        self.cache.increment_generation();
+    }
+}
+
 impl<'c> fmt::Debug for Session<'c> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "Session({:?}, {:?})", self.query_path, self.substitute_file)

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -524,29 +524,36 @@ impl<'c> Session<'c> {
         }
     }
 
+    /// Resolve appropriate path for current query
+    ///
+    /// If path is the query path, returns the substitute file
+    fn resolve_path<'a>(&'a self, path: &'a path::Path) -> &path::Path {
+        if path == self.query_path.as_path() {
+            &self.substitute_file
+        } else {
+            path
+        }
+    }
+
     pub fn cache_file_contents<T>(&self, filepath: &path::Path, buf: T)
     where T: Into<String> {
         self.cache.cache_file_contents(filepath, buf);
     }
 
     pub fn open_file(&self, path: &path::Path) -> io::Result<File> {
-        if path == self.query_path.as_path() {
-            self.cache.open_file(&self.substitute_file)
-        } else {
-            self.cache.open_file(path)
-        }
+        self.cache.open_file(self.resolve_path(path))
     }
 
     pub fn read_file(&self, path: &path::Path) -> Vec<u8> {
-        self.cache.read_file(path)
+        self.cache.read_file(self.resolve_path(path))
     }
 
     pub fn load_file(&self, filepath: &path::Path) -> Src<'c> {
-        self.cache.load_file(filepath)
+        self.cache.load_file(self.resolve_path(filepath))
     }
 
     pub fn load_file_and_mask_comments(&self, filepath: &path::Path) -> Src<'c> {
-        self.cache.load_file_and_mask_comments(filepath)
+        self.cache.load_file_and_mask_comments(self.resolve_path(filepath))
     }
 }
 

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -1,5 +1,5 @@
 use {scopes, typeinf, ast};
-use core::{Match, PathSegment, Src, SessionRef};
+use core::{Match, PathSegment, Src, Session};
 use util::{symbol_matches, txt_matches, find_ident_end, is_ident_char, char_at};
 use nameres::{get_module_file, get_crate_file, resolve_path};
 use core::SearchType::{self, StartsWith, ExactMatch};
@@ -17,7 +17,7 @@ pub type MChain<T> = iter::Chain<T, MIter>;
 pub fn match_types(src: Src, blobstart: usize, blobend: usize,
                    searchstr: &str, filepath: &Path,
                    search_type: SearchType,
-                   local: bool, session: SessionRef) -> iter::Chain<MChain<MChain<MChain<MChain<MChain<MIter>>>>>, vec::IntoIter<Match>> {
+                   local: bool, session: &Session) -> iter::Chain<MChain<MChain<MChain<MChain<MChain<MIter>>>>>, vec::IntoIter<Match>> {
     let it = match_extern_crate(&src, blobstart, blobend, searchstr, filepath, search_type, session).into_iter();
     let it = it.chain(match_mod(src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
     let it = it.chain(match_struct(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
@@ -218,7 +218,7 @@ pub fn first_line(blob: &str) -> String {
 
 pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
                           searchstr: &str, filepath: &Path, search_type: SearchType,
-                          session: SessionRef) -> Option<Match> {
+                          session: &Session) -> Option<Match> {
     let mut res = None;
     let blob = &msrc[blobstart..blobend];
 
@@ -476,7 +476,7 @@ thread_local!(static ALREADY_GLOBBING: Cell<Option<bool>> = Cell::new(None));
 
 pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                  searchstr: &str, filepath: &Path, search_type: SearchType,
-                 local: bool, session: SessionRef) -> Vec<Match> {
+                 local: bool, session: &Session) -> Vec<Match> {
     let mut out = Vec::new();
     let blob = &msrc[blobstart..blobend];
 

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -1,5 +1,5 @@
 use {ast, typeinf, util};
-use core::{Src, SessionRef, CompletionType};
+use core::{Src, CompletionType, Session};
 #[cfg(test)] use core;
 
 use std::iter::Iterator;
@@ -291,7 +291,7 @@ pub fn point_to_coords(src: &str, point: usize) -> (usize, usize) {
     (nlines, point - linestart)
 }
 
-pub fn point_to_coords_from_file(path: &Path, point: usize, session: SessionRef) -> Option<(usize, usize)> {
+pub fn point_to_coords_from_file(path: &Path, point: usize, session: &Session) -> Option<(usize, usize)> {
     let mut lineno = 0;
     let mut p = 0;
     for line in session.load_file(path).split('\n') {

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -1,10 +1,10 @@
 use ast::with_error_checking_parse;
-use core::{Match, MatchType, SessionRef};
+use core::{Match, MatchType, Session};
 use typeinf::get_function_declaration;
 
 use syntex_syntax::ast::ImplItemKind;
 
-pub fn snippet_for_match(m: &Match, session: SessionRef) -> String {
+pub fn snippet_for_match(m: &Match, session: &Session) -> String {
     match m.mtype {
         MatchType::Function => {
             let method = get_function_declaration(&m, session);

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -1,14 +1,14 @@
 // Small functions of utility
 
 use core::SearchType::{self, ExactMatch, StartsWith};
-use core::SessionRef;
+use core::Session;
 use std;
 use std::cmp;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-pub fn getline(filepath: &Path, linenum: usize, session: SessionRef) -> String {
+pub fn getline(filepath: &Path, linenum: usize, session: &Session) -> String {
     let reader = BufReader::new(session.open_file(filepath).unwrap());
     reader.lines().nth(linenum - 1).unwrap_or(Ok("not found".into())).unwrap()
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -79,6 +79,34 @@ fn completes_pub_fn_locally_precached() {
 }
 
 #[test]
+fn overwriting_cached_files() {
+    let src1 = "src1";
+    let src2 = "src2";
+    let src3 = "src3";
+    let src4 = "src4";
+
+    // Need session and path to cache files
+    let path = tmpname();
+    let session = core::Session::from_path(&path, &path);
+
+    // Cache contents for a file and assert that load_file and load_file_and_mask_comments return
+    // the newly cached contents.
+    macro_rules! cache_and_assert {
+        ($src:ident) => {{
+            session.cache_file_contents(&path, $src);
+            assert_eq!($src, &session.load_file(&path).src.code[..]);
+            assert_eq!($src, &session.load_file_and_mask_comments(&path).src.code[..]);
+        }}
+    }
+
+    // Check for all srcN
+    cache_and_assert!(src1);
+    cache_and_assert!(src2);
+    cache_and_assert!(src3);
+    cache_and_assert!(src4);
+}
+
+#[test]
 fn completes_pub_const_fn_locally() {
     let src="
     pub const fn apple() {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -62,6 +62,23 @@ fn completes_pub_fn_locally() {
 }
 
 #[test]
+fn completes_pub_fn_locally_precached() {
+    let src="
+    pub fn apple() {
+    }
+
+    fn main() {
+        let b = ap
+    }";
+    let path = tmpname();
+    let pos = scopes::coords_to_point(src, 6, 18);
+    let session = core::Session::from_path(&path, &path);
+    session.cache_file_contents(&path, src);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    assert_eq!("apple".to_string(), got.matchstr.to_string());
+}
+
+#[test]
 fn completes_pub_const_fn_locally() {
     let src="
     pub const fn apple() {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -12,6 +12,15 @@ use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::thread;
 
+// fn with_session<U, F>(query_path: &path::Path, substitute_file: &path::Path, func: F) -> U
+// where F: FnOnce(&core::Session) -> U {
+// 
+//     let cache = core::FileCache::new();
+//     let session = core::Session::from_path(cache, query_path, substitute_file);
+// 
+//     func(&session)
+// }
+
 fn tmpname() -> PathBuf {
     let thread = thread::current();
     let taskname = thread.name().unwrap();
@@ -39,7 +48,13 @@ fn completes_fn() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 18);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    // let got = with_session(&path, &path, |session| {
+    //     complete_from_file(src, &path, pos, session).nth(0).unwrap()
+    // });
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
@@ -56,7 +71,9 @@ fn completes_pub_fn_locally() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 18);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
@@ -72,7 +89,8 @@ fn completes_pub_fn_locally_precached() {
     }";
     let path = tmpname();
     let pos = scopes::coords_to_point(src, 6, 18);
-    let session = core::Session::from_path(&path, &path);
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
     session.cache_file_contents(&path, src);
     let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
@@ -87,7 +105,8 @@ fn overwriting_cached_files() {
 
     // Need session and path to cache files
     let path = tmpname();
-    let session = core::Session::from_path(&path, &path);
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
 
     // Cache contents for a file and assert that load_file and load_file_and_mask_comments return
     // the newly cached contents.
@@ -118,7 +137,9 @@ fn completes_pub_const_fn_locally() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 18);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
@@ -133,7 +154,9 @@ fn completes_local_scope_let() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 18);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr);
     assert_eq!(29, got.point);
@@ -151,7 +174,9 @@ fn main() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 18);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr);
     assert_eq!(25, got.point);
@@ -183,9 +208,13 @@ fn main() { // l16
     let path = tmpname();
     write_file(&path, src);
     let pos1 = scopes::coords_to_point(src, 18, 14);  // sub::Foo::
-    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&path, &path)).nth(0);
+    let cache1 = core::FileCache::new();
+    let session1 = core::Session::from_path(&cache1, &path, &path);
+    let got1 = complete_from_file(src, &path, pos1, &session1).nth(0);
     let pos2 = scopes::coords_to_point(src, 19, 7);   // t.t
-    let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&path, &path)).nth(0);
+    let cache2 = core::FileCache::new();
+    let session2 = core::Session::from_path(&cache2, &path, &path);
+    let got2 = complete_from_file(src, &path, pos2, &session2).nth(0);
     fs::remove_file(&path).unwrap();
     println!("{:?}", got1);
     println!("{:?}", got2);
@@ -210,7 +239,9 @@ fn follows_use() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 10);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr,"myfn".to_string());
 }
@@ -232,7 +263,9 @@ fn follows_use_as() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 10);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
 }
@@ -254,7 +287,9 @@ fn follows_use_glob() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 10);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
 }
@@ -273,7 +308,9 @@ fn completes_struct_field_via_assignment() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 9);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("first".to_string(), got.matchstr);
 }
@@ -292,7 +329,9 @@ fn finds_defn_of_struct_field() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 9);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "first".to_string());
 }
@@ -310,7 +349,9 @@ fn finds_impl_fn() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 7, 10);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "new".to_string());
 }
@@ -330,7 +371,9 @@ fn follows_use_to_inline_mod() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 9);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
 }
@@ -348,7 +391,9 @@ fn finds_enum() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 16);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "MyEnum".to_string());
 }
@@ -363,7 +408,9 @@ fn finds_type() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 5);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "SpannedIdent".to_string());
 }
@@ -378,7 +425,9 @@ fn finds_trait() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 5);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "MyTrait".to_string());
 }
@@ -394,7 +443,9 @@ fn finds_fn_arg() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 10);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myarg".to_string());
 }
@@ -409,7 +460,9 @@ fn finds_fn_arg_in_incomplete_fn() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 10);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myarg".to_string());
 }
@@ -427,7 +480,9 @@ fn finds_inline_fn() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 9);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "contains".to_string());
 }
@@ -459,7 +514,9 @@ fn follows_self_use() {
     let srcpath = basedir.join("src.rs");
     write_file(&srcpath, src);
     let pos = scopes::coords_to_point(src, 6, 10);
-    let got = find_definition(src, &srcpath, pos, &core::Session::from_path(&srcpath, &srcpath)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &srcpath, &srcpath);
+    let got = find_definition(src, &srcpath, pos, &session).unwrap();
     fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
     assert_eq!(moddir.join("src4.rs").display().to_string(),
@@ -489,7 +546,9 @@ fn finds_nested_submodule_file() {
     write_file(&srcpath, rootsrc);
     write_file(&sub2dir.join("sub3.rs"), sub3src);
     let pos = scopes::coords_to_point(rootsrc, 7, 23);
-    let got = find_definition(rootsrc, &srcpath, pos, &core::Session::from_path(&srcpath, &srcpath)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &srcpath, &srcpath);
+    let got = find_definition(rootsrc, &srcpath, pos, &session).unwrap();
     fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
     assert_eq!(sub2dir.join("sub3.rs").display().to_string(),
@@ -505,7 +564,9 @@ fn follows_super_in_sub_module() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 33);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("iamhere", got.matchstr);
 }
@@ -521,7 +582,9 @@ fn follows_super_in_local_sub_module() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 38);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("iamhere", got.matchstr);
 }
@@ -551,7 +614,9 @@ fn follows_use_to_impl() {
     let srcpath = basedir.join("src.rs");
     write_file(&srcpath, src);
     let pos = scopes::coords_to_point(src, 5, 14);
-    let got = find_definition(src, &srcpath, pos, &core::Session::from_path(&srcpath, &srcpath)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &srcpath, &srcpath);
+    let got = find_definition(src, &srcpath, pos, &session).unwrap();
 
     fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got.matchstr, "new".to_string());
@@ -573,7 +638,9 @@ fn finds_templated_impl_fn() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 7, 10);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "new".to_string());
 }
@@ -595,7 +662,9 @@ fn follows_fn_to_method() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 10, 12);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
 }
@@ -615,7 +684,9 @@ fn follows_arg_to_method() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 12);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
 }
@@ -637,7 +708,9 @@ fn follows_arg_to_enum_method() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 10, 12);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
 }
@@ -662,7 +735,9 @@ fn follows_let_method_call() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 13, 12);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mybarmethod".to_string(), got.matchstr);
 }
@@ -686,7 +761,9 @@ fn follows_chained_method_call() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 12, 23);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mybarmethod".to_string(), got.matchstr);
 }
@@ -709,7 +786,9 @@ fn discards_inner_fns() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 11, 11);
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path)).nth(0);
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = complete_from_file(src, &path, pos, &session).nth(0);
     fs::remove_file(&path).unwrap();
     assert!(got.is_none(), "should not match inner function");
 }
@@ -725,7 +804,9 @@ fn differentiates_type_and_value_namespaces() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 18);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     println!("{}", got.matchstr);
     println!("{:?}", got.mtype);
@@ -747,7 +828,9 @@ fn follows_self_to_method() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 20);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("method", got.matchstr);
 }
@@ -769,7 +852,9 @@ fn follows_self_to_method_when_call_on_new_line() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 20);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("method", got.matchstr);
 }
@@ -787,7 +872,9 @@ fn follows_self_to_trait_method() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 20);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("method", got.matchstr);
 }
@@ -809,7 +896,9 @@ fn finds_trait_method() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 10, 22);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("trait_method", got.matchstr);
 }
@@ -829,7 +918,9 @@ fn finds_field_type() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 16);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -847,7 +938,9 @@ fn finds_a_generic_retval_from_a_function() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 7, 24);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -870,7 +963,9 @@ fn handles_an_enum_option_style_return_type() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 12, 18);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -884,7 +979,9 @@ fn finds_definition_of_const() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 7);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MYCONST", got.matchstr);
 }
@@ -898,7 +995,9 @@ fn finds_definition_of_static() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 7);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MYSTATIC", got.matchstr);
 }
@@ -912,7 +1011,9 @@ fn handles_dotdot_before_searchstr() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 22);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MYLEN", got.matchstr);
 }
@@ -927,7 +1028,9 @@ fn finds_definition_of_lambda_argument() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 12);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -941,7 +1044,9 @@ fn finds_definition_of_let_tuple() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 4);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -956,7 +1061,9 @@ fn finds_type_of_tuple_member_via_let_type() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 11);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -971,7 +1078,9 @@ fn finds_type_of_tuple_member_via_let_expr() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 11);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -987,7 +1096,9 @@ fn finds_type_of_tuple_member_via_fn_retval() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 11);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1003,7 +1114,9 @@ fn finds_type_of_tuple_member_in_fn_arg() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 11);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1017,7 +1130,9 @@ fn finds_namespaced_enum_variant() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 14);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MyVariant", got.matchstr);
 }
@@ -1032,7 +1147,9 @@ fn finds_glob_imported_enum_variant() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 8);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MyVariant", got.matchstr);
 }
@@ -1051,7 +1168,9 @@ fn uses_generic_arg_to_resolve_trait_method() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 19);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("trait_method", got.matchstr);
 }
@@ -1067,7 +1186,9 @@ fn destructures_a_tuplestruct() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 10);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1084,7 +1205,9 @@ fn destructures_a_tuplestruct_with_generic_arg() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 10);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1099,7 +1222,9 @@ fn finds_if_let_ident_defn() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 13);
-    let mut it = complete_from_file(src, &path, pos, &core::Session::from_path(&path, &path));
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let mut it = complete_from_file(src, &path, pos, &session);
     let got = it.next().unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("myvar", &*got.matchstr);
@@ -1118,7 +1243,9 @@ fn doesnt_find_if_let_if_not_in_the_subscope() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 6);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("myvar", &*got.matchstr);
     assert_eq!(9, got.point);
@@ -1135,7 +1262,9 @@ fn finds_rebound_var_in_iflet() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 8);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(56, got.point);
 }
@@ -1156,7 +1285,9 @@ fn handles_if_let() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 13);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1177,7 +1308,9 @@ fn handles_if_let_as_expression() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 13);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1191,7 +1324,9 @@ fn finds_match_arm_var() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 18);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -1205,7 +1340,9 @@ fn finds_match_arm_var_in_scope() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 20);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -1224,7 +1361,9 @@ fn finds_match_arm_enum() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 7, 18);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("Foo", got.matchstr);
 }
@@ -1244,7 +1383,9 @@ fn finds_match_arm_var_with_nested_match() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 15);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -1264,7 +1405,9 @@ fn gets_type_via_match_arm() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 38);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1281,7 +1424,9 @@ fn handles_default_arm() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 13);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("o", got.matchstr);
     assert_eq!(9, got.point);
@@ -1296,7 +1441,9 @@ fn doesnt_match_rhs_of_let_in_same_stmt() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 12);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
     assert_eq!(9, got.point);
@@ -1321,7 +1468,9 @@ fn finds_unsafe_fn() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 9);
-    let got = find_definition(src, &path, pos, &core::Session::from_path(&path, &path)).unwrap();
+    let cache = core::FileCache::new();
+    let session = core::Session::from_path(&cache, &path, &path);
+    let got = find_definition(src, &path, pos, &session).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "foo".to_string());
     assert_eq!(got.point, 15);

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -106,12 +106,12 @@ fn overwriting_cached_files() {
     // Need session and path to cache files
     let path = tmpname();
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
 
     // Cache contents for a file and assert that load_file and load_file_and_mask_comments return
     // the newly cached contents.
     macro_rules! cache_and_assert {
         ($src:ident) => {{
+            let session = core::Session::from_path(&cache, &path, &path);
             session.cache_file_contents(&path, $src);
             assert_eq!($src, &session.load_file(&path).src.code[..]);
             assert_eq!($src, &session.load_file_and_mask_comments(&path).src.code[..]);

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -47,6 +47,27 @@ fn completes_fn() {
 }
 
 #[test]
+fn completes_fn_with_substitute_file() {
+    let src="
+    fn   apple() {
+    }
+
+    fn main() {
+        let b = ap
+    }";
+    let substitute_file = tmpname();
+    write_file(&substitute_file, src);
+    let pos = scopes::coords_to_point(src, 6, 18);
+    let cache = core::FileCache::new();
+    let real_file = &Path::new("not_real.rs");
+    let session = core::Session::from_path(&cache, &real_file, &substitute_file);
+    let got = complete_from_file(src, &real_file, pos, &session).nth(0).unwrap();
+
+    fs::remove_file(&substitute_file).unwrap();
+    assert_eq!("apple".to_string(), got.matchstr.to_string());
+}
+
+#[test]
 fn completes_pub_fn_locally() {
     let src="
     pub fn apple() {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -12,15 +12,6 @@ use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::thread;
 
-// fn with_session<U, F>(query_path: &path::Path, substitute_file: &path::Path, func: F) -> U
-// where F: FnOnce(&core::Session) -> U {
-// 
-//     let cache = core::FileCache::new();
-//     let session = core::Session::from_path(cache, query_path, substitute_file);
-// 
-//     func(&session)
-// }
-
 fn tmpname() -> PathBuf {
     let thread = thread::current();
     let taskname = thread.name().unwrap();
@@ -48,12 +39,8 @@ fn completes_fn() {
     let path = tmpname();
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 18);
-    // let got = with_session(&path, &path, |session| {
-    //     complete_from_file(src, &path, pos, session).nth(0).unwrap()
-    // });
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
 
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
@@ -72,8 +59,7 @@ fn completes_pub_fn_locally() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 18);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
@@ -138,8 +124,7 @@ fn completes_pub_const_fn_locally() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 18);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
@@ -155,8 +140,7 @@ fn completes_local_scope_let() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 18);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr);
     assert_eq!(29, got.point);
@@ -175,8 +159,7 @@ fn main() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 18);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr);
     assert_eq!(25, got.point);
@@ -209,12 +192,10 @@ fn main() { // l16
     write_file(&path, src);
     let pos1 = scopes::coords_to_point(src, 18, 14);  // sub::Foo::
     let cache1 = core::FileCache::new();
-    let session1 = core::Session::from_path(&cache1, &path, &path);
-    let got1 = complete_from_file(src, &path, pos1, &session1).nth(0);
+    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0);
     let pos2 = scopes::coords_to_point(src, 19, 7);   // t.t
     let cache2 = core::FileCache::new();
-    let session2 = core::Session::from_path(&cache2, &path, &path);
-    let got2 = complete_from_file(src, &path, pos2, &session2).nth(0);
+    let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&cache2, &path, &path)).nth(0);
     fs::remove_file(&path).unwrap();
     println!("{:?}", got1);
     println!("{:?}", got2);
@@ -240,8 +221,7 @@ fn follows_use() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr,"myfn".to_string());
 }
@@ -264,8 +244,7 @@ fn follows_use_as() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
 }
@@ -288,8 +267,7 @@ fn follows_use_glob() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
 }
@@ -309,8 +287,7 @@ fn completes_struct_field_via_assignment() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 9);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("first".to_string(), got.matchstr);
 }
@@ -330,8 +307,7 @@ fn finds_defn_of_struct_field() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 9);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "first".to_string());
 }
@@ -350,8 +326,7 @@ fn finds_impl_fn() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 7, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "new".to_string());
 }
@@ -372,8 +347,7 @@ fn follows_use_to_inline_mod() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 9);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
 }
@@ -392,8 +366,7 @@ fn finds_enum() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 16);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "MyEnum".to_string());
 }
@@ -409,8 +382,7 @@ fn finds_type() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 5);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "SpannedIdent".to_string());
 }
@@ -426,8 +398,7 @@ fn finds_trait() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 5);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "MyTrait".to_string());
 }
@@ -444,8 +415,7 @@ fn finds_fn_arg() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myarg".to_string());
 }
@@ -461,8 +431,7 @@ fn finds_fn_arg_in_incomplete_fn() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myarg".to_string());
 }
@@ -481,8 +450,7 @@ fn finds_inline_fn() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 9);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "contains".to_string());
 }
@@ -515,8 +483,7 @@ fn follows_self_use() {
     write_file(&srcpath, src);
     let pos = scopes::coords_to_point(src, 6, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &srcpath, &srcpath);
-    let got = find_definition(src, &srcpath, pos, &session).unwrap();
+    let got = find_definition(src, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath)).unwrap();
     fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
     assert_eq!(moddir.join("src4.rs").display().to_string(),
@@ -547,8 +514,7 @@ fn finds_nested_submodule_file() {
     write_file(&sub2dir.join("sub3.rs"), sub3src);
     let pos = scopes::coords_to_point(rootsrc, 7, 23);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &srcpath, &srcpath);
-    let got = find_definition(rootsrc, &srcpath, pos, &session).unwrap();
+    let got = find_definition(rootsrc, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath)).unwrap();
     fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
     assert_eq!(sub2dir.join("sub3.rs").display().to_string(),
@@ -565,8 +531,7 @@ fn follows_super_in_sub_module() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 33);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("iamhere", got.matchstr);
 }
@@ -583,8 +548,7 @@ fn follows_super_in_local_sub_module() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 38);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("iamhere", got.matchstr);
 }
@@ -615,8 +579,7 @@ fn follows_use_to_impl() {
     write_file(&srcpath, src);
     let pos = scopes::coords_to_point(src, 5, 14);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &srcpath, &srcpath);
-    let got = find_definition(src, &srcpath, pos, &session).unwrap();
+    let got = find_definition(src, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath)).unwrap();
 
     fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got.matchstr, "new".to_string());
@@ -639,8 +602,7 @@ fn finds_templated_impl_fn() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 7, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "new".to_string());
 }
@@ -663,8 +625,7 @@ fn follows_fn_to_method() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 10, 12);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
 }
@@ -685,8 +646,7 @@ fn follows_arg_to_method() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 12);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
 }
@@ -709,8 +669,7 @@ fn follows_arg_to_enum_method() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 10, 12);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
 }
@@ -736,8 +695,7 @@ fn follows_let_method_call() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 13, 12);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mybarmethod".to_string(), got.matchstr);
 }
@@ -762,8 +720,7 @@ fn follows_chained_method_call() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 12, 23);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("mybarmethod".to_string(), got.matchstr);
 }
@@ -787,8 +744,7 @@ fn discards_inner_fns() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 11, 11);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = complete_from_file(src, &path, pos, &session).nth(0);
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0);
     fs::remove_file(&path).unwrap();
     assert!(got.is_none(), "should not match inner function");
 }
@@ -805,8 +761,7 @@ fn differentiates_type_and_value_namespaces() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 18);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     println!("{}", got.matchstr);
     println!("{:?}", got.mtype);
@@ -829,8 +784,7 @@ fn follows_self_to_method() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 20);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("method", got.matchstr);
 }
@@ -853,8 +807,7 @@ fn follows_self_to_method_when_call_on_new_line() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 20);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("method", got.matchstr);
 }
@@ -873,8 +826,7 @@ fn follows_self_to_trait_method() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 20);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("method", got.matchstr);
 }
@@ -897,8 +849,7 @@ fn finds_trait_method() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 10, 22);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("trait_method", got.matchstr);
 }
@@ -919,8 +870,7 @@ fn finds_field_type() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 16);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -939,8 +889,7 @@ fn finds_a_generic_retval_from_a_function() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 7, 24);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -964,8 +913,7 @@ fn handles_an_enum_option_style_return_type() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 12, 18);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -980,8 +928,7 @@ fn finds_definition_of_const() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 7);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MYCONST", got.matchstr);
 }
@@ -996,8 +943,7 @@ fn finds_definition_of_static() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 7);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MYSTATIC", got.matchstr);
 }
@@ -1012,8 +958,7 @@ fn handles_dotdot_before_searchstr() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 22);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MYLEN", got.matchstr);
 }
@@ -1029,8 +974,7 @@ fn finds_definition_of_lambda_argument() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 12);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -1045,8 +989,7 @@ fn finds_definition_of_let_tuple() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 4);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -1062,8 +1005,7 @@ fn finds_type_of_tuple_member_via_let_type() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 11);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1079,8 +1021,7 @@ fn finds_type_of_tuple_member_via_let_expr() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 11);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1097,8 +1038,7 @@ fn finds_type_of_tuple_member_via_fn_retval() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 11);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1115,8 +1055,7 @@ fn finds_type_of_tuple_member_in_fn_arg() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 11);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1131,8 +1070,7 @@ fn finds_namespaced_enum_variant() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 14);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MyVariant", got.matchstr);
 }
@@ -1148,8 +1086,7 @@ fn finds_glob_imported_enum_variant() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 8);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("MyVariant", got.matchstr);
 }
@@ -1169,8 +1106,7 @@ fn uses_generic_arg_to_resolve_trait_method() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 19);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("trait_method", got.matchstr);
 }
@@ -1187,8 +1123,7 @@ fn destructures_a_tuplestruct() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1206,8 +1141,7 @@ fn destructures_a_tuplestruct_with_generic_arg() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 10);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1223,8 +1157,7 @@ fn finds_if_let_ident_defn() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 13);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let mut it = complete_from_file(src, &path, pos, &session);
+    let mut it = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path));
     let got = it.next().unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("myvar", &*got.matchstr);
@@ -1244,8 +1177,7 @@ fn doesnt_find_if_let_if_not_in_the_subscope() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 6, 6);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("myvar", &*got.matchstr);
     assert_eq!(9, got.point);
@@ -1263,8 +1195,7 @@ fn finds_rebound_var_in_iflet() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 4, 8);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(56, got.point);
 }
@@ -1286,8 +1217,7 @@ fn handles_if_let() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 13);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1309,8 +1239,7 @@ fn handles_if_let_as_expression() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 13);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1325,8 +1254,7 @@ fn finds_match_arm_var() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 18);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -1341,8 +1269,7 @@ fn finds_match_arm_var_in_scope() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 20);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -1362,8 +1289,7 @@ fn finds_match_arm_enum() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 7, 18);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("Foo", got.matchstr);
 }
@@ -1384,8 +1310,7 @@ fn finds_match_arm_var_with_nested_match() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 8, 15);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
@@ -1406,8 +1331,7 @@ fn gets_type_via_match_arm() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 9, 38);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
@@ -1425,8 +1349,7 @@ fn handles_default_arm() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 13);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("o", got.matchstr);
     assert_eq!(9, got.point);
@@ -1442,8 +1365,7 @@ fn doesnt_match_rhs_of_let_in_same_stmt() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 3, 12);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
     assert_eq!(9, got.point);
@@ -1469,8 +1391,7 @@ fn finds_unsafe_fn() {
     write_file(&path, src);
     let pos = scopes::coords_to_point(src, 5, 9);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &path, &path);
-    let got = find_definition(src, &path, pos, &session).unwrap();
+    let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "foo".to_string());
     assert_eq!(got.point, 15);


### PR DESCRIPTION
**TL;DR**
- Adds `cache_file_contents` method to session for caching in-memory buffers/files
- Adds some unsafe code to `FileCache` / `Session` to support Arena allocation reuse
- API changes - `Session::from_path` takes additional argument, and `SessionRef` was obsoleted.

## Changes

The Session type now has an additional method `cache_file_contents` which enables consumers to write in-memory buffers into the file cache for use in racer operations. This feature is critical for projects like [racerd][] which run for extended periods and rely on caching for performance.

Initially, this introduced a memory leak since Arena allocations could not be reused, but this was fixed with some changes to the FileCache. The FileCache now proxies Arena `alloc` calls and first consults a free list. The `alloc` proxy was able to be implemented as a safe API, but the free operation `update_available_allocations` is inherently unsafe, and this is exposed as part of the API. To be 100% safe, this operation would need to know statically that there are no outstanding references to the item being freed. To guarantee this, file cache references are only accessed via a Session. When a session is dropped, it is known that it has no outstanding references, and at this point we can call `update_available_allocations`.

Since the Session now requires a reference to the FileCache, a bunch of the session lifetime restrictions were lifted. This accounts for many of the scattered changes in this PR including obsoleting the SessionRef type (thanks @birkenfeld). Additionally, all of the tests had to be updated to reflect the new Session API.

## Discussion

The caching feature added here is important for racer's story as a library. I think the main focus of discussion here should be with regards to how the Arena allocation reuse was achieved. Other proposed implementations of reap allocators use smart pointers to track active references and achieve a safe API. It's not clear to me whether the smart pointers would actually be any better than the previous `Rc` strategy the Session used. I would like to land this PR soon to ship [racerd][] for YCM using the official racer repository, but I understand if you would rather wait until an actual Reap allocator implementation is available.

[racerd]: https://github.com/jwilm/racerd