### PR TITLE
Completions for Deref Coercions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "racer"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -127,7 +127,6 @@ pub enum Ty {
     TyMatch(Match),
     TyPathSearch(Path, Scope),   // A path + the scope to be able to resolve it
     TyTuple(Vec<Ty>),
-    TyMatchVec(Vec<Match>),
     TyUnsupported
 }
 
@@ -588,20 +587,10 @@ pub fn complete_from_file(src: &str, filepath: &path::Path, pos: usize, session:
             let context = ast::get_type_of(contextstr.to_owned(), filepath, pos, session);
             debug!("complete_from_file context is {:?}", context);
             context.map(|ty| {
-                match ty {
-                    Ty::TyMatch(m) => {
-                        for m in nameres::search_for_field_or_method(m, searchstr, SearchType::StartsWith, session) {
-                            out.push(m)
-                        }
-                    },
-                    Ty::TyMatchVec(vm) =>  {
-                        for m in vm{
-                            for m in nameres::search_for_field_or_method(m, searchstr, SearchType::StartsWith, session) {
-                                out.push(m)
-                            }
-                        }
-                    },
-                    _ => (),
+                if let Ty::TyMatch(m) = ty {
+                    for m in nameres::search_for_field_or_method(m, searchstr, SearchType::StartsWith, session) {
+                        out.push(m)
+                    }
                 }
             });
         }


### PR DESCRIPTION
This fixes Issue #455 by recursively completing on coerced types (see the new tests for examples).   

Since this also retroactively solves issue #438 I've removed the changes from my earlier commit #439 as it is now redundant.

N.B. For the tests I had to copy over the definition of the Deref trait since it appears that travis.ci cannot find the source code for crate std.