### PR TITLE
Read substitute file from stdin

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -24,6 +24,8 @@ use racer::scopes;
 #[cfg(not(test))]
 use std::path::{Path, PathBuf};
 #[cfg(not(test))]
+use std::io::{self, BufRead};
+#[cfg(not(test))]
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 #[cfg(not(test))]
@@ -118,12 +120,28 @@ enum CompletePrinter {
 }
 
 #[cfg(not(test))]
+fn cache_file_contents_from_stdin<'a>(file: &PathBuf, cache: &'a core::FileCache<'a>) {
+    let stdin = io::stdin();
+
+    let mut rawbytes = Vec::new();
+    stdin.lock().read_until(0x04, &mut rawbytes).unwrap();
+
+    let buf = String::from_utf8(rawbytes).unwrap();
+    cache.cache_file_contents(file, buf);
+}
+
+#[cfg(not(test))]
 fn run_the_complete_fn(cfg: &Config, print_type: CompletePrinter) {
     let fn_path = &*cfg.fn_name.as_ref().unwrap();
     let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
 
     let cache = core::FileCache::new();
     let session = core::Session::from_path(&cache, fn_path, substitute_file);
+
+    if substitute_file.to_str() == Some("-") {
+        cache_file_contents_from_stdin(&substitute_file, &cache);
+    }
+
     let src = session.load_file(fn_path);
     let line = &getline(substitute_file, cfg.linenum, &session);
     let (start, pos) = util::expand_ident(line, cfg.charnum);
@@ -169,8 +187,13 @@ fn external_complete(cfg: Config) {
 #[cfg(not(test))]
 fn prefix(cfg: Config) {
     let fn_path = &*cfg.fn_name.as_ref().unwrap();
+    let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, fn_path, cfg.substitute_file.as_ref().unwrap_or(fn_path));
+    let session = core::Session::from_path(&cache, fn_path, substitute_file);
+
+    if substitute_file.to_str() == Some("-") {
+        cache_file_contents_from_stdin(&substitute_file, &cache);
+    }
 
     // print the start, end, and the identifier prefix being matched
     let line = &getline(fn_path, cfg.linenum, &session);
@@ -186,8 +209,14 @@ fn prefix(cfg: Config) {
 #[cfg(not(test))]
 fn find_definition(cfg: Config) {
     let fn_path = &*cfg.fn_name.as_ref().unwrap();
+    let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, fn_path, cfg.substitute_file.as_ref().unwrap_or(fn_path));
+    let session = core::Session::from_path(&cache, fn_path, substitute_file);
+
+    if substitute_file.to_str() == Some("-") {
+        cache_file_contents_from_stdin(&substitute_file, &cache);
+    }
+
     let src = session.load_file(fn_path);
     let pos = scopes::coords_to_point(&src, cfg.linenum, cfg.charnum);
 
@@ -229,7 +258,6 @@ fn check_rust_src_env_var() {
 
 #[cfg(not(test))]
 fn daemon(cfg: Config) {
-    use std::io;
     let mut input = String::new();
     while let Ok(n) = io::stdin().read_line(&mut input) {
         // '\n' == 1

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -5,12 +5,11 @@ use core::Session;
 use std;
 use std::cmp;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 pub fn getline(filepath: &Path, linenum: usize, session: &Session) -> String {
-    let reader = BufReader::new(session.open_file(filepath).unwrap());
-    reader.lines().nth(linenum - 1).unwrap_or(Ok("not found".into())).unwrap()
+    let src = session.load_file(filepath);
+    src.src.code.lines().nth(linenum - 1).unwrap_or("not found").to_string()
 }
 
 pub fn is_pattern_char(c: char) -> bool {


### PR DESCRIPTION
Hello!

Not all editors use temp-files (or don't expose them to plugin authors). I made it possible for the substitute file to be read from stdin if you specify "-" as the substitute_file.

Is this functionality something you would be interested in merging? In that case i will continue to work on it. There are a few things that still needs doing.

- Check/fix for daemon mode
- Make testable and add tests

If you are curious, I am working on a plugin for [Visual Studio Code](https://code.visualstudio.com/).

The plugin is located at https://github.com/henriiik/vscode-rust.