### PR TITLE
Read packages source when library name is different from package name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,8 +1,8 @@
 [root]
 name = "racer"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
- "clap 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,7 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -45,7 +45,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.44"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ dependencies = [
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test_fixtures 0.1.0",
  "toml 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -124,6 +125,10 @@ dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "test_fixtures"
+version = "0.1.0"
 
 [[package]]
 name = "toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "racer"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT"
 description = "Code completion for Rust"
 authors = ["Phil Dawes <phil@phildawes.net>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,8 @@ env_logger = "~0.3.2"
 typed-arena = "~1.0.1"
 clap = "~1.5.3"
 
+[dev-dependencies]
+test_fixtures = { path = "src/test_fixtures" }
+
 [features]
 nightly = []

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -304,7 +304,7 @@ fn build_cli<'a, 'b, 'c, 'd, 'e, 'f>() -> App<'a, 'b, 'c, 'd, 'e, 'f> {
     // than the less verbose "Usage String" method...faster, meaning runtime speed since that's
     // extremely important here
     App::new("racer")
-        .version("v1.1.0")
+        .version("v1.2.0")
         .author("Phil Dawes")
         .about("A Rust code completion utility")
         .settings(&[AppSettings::GlobalVersion,

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -10,7 +10,7 @@ use toml;
 #[derive(Debug)]
 struct PackageInfo {
     name: String,
-    version: String,
+    version: Option<String>,
     source: Option<PathBuf>
 }
 
@@ -84,7 +84,6 @@ fn find_src_via_lockfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
             }
         }
     }
-
     None
 }
 
@@ -136,13 +135,12 @@ fn get_cargo_packages(cargofile: &Path) -> Option<Vec<PackageInfo>> {
 
                 result.push(PackageInfo{
                     name: package_name.to_owned(),
-                    version: package_version,
+                    version: Some(package_version),
                     source: package_source
                 });
             }
         }
     }
-
     Some(result)
 }
 
@@ -298,13 +296,7 @@ fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> 
 fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
     // only look for 'path' references here.
     // We find the git and crates.io stuff via the lockfile
-
-    let mut file = otry2!(File::open(cargofile));
-    let mut string = String::new();
-    otry2!(file.read_to_string(&mut string));
-    let mut parser = toml::Parser::new(&string);
-    let table = otry!(parser.parse());
-
+    let table = parse_toml_file(cargofile).unwrap();
 
     // is it this lib?  (e.g. you're searching from tests to find the main library crate)
     {
@@ -340,36 +332,66 @@ fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
     }
 
     // otherwise search the dependencies
-    let t = match table.get("dependencies") {
+    let local_packages = get_local_packages(&table, cargofile, "dependencies").unwrap();
+    let local_packages_dev = get_local_packages(&table, cargofile, "dev-dependencies").unwrap();
+
+    debug!("find_src_via_tomlfile found local packages: {:?}", local_packages);
+    debug!("find_src_via_tomlfile found local packages dev: {:?}", local_packages_dev);
+
+    for package in local_packages.iter().chain(local_packages_dev.iter()) {
+        if let Some(package_source) = package.source.clone() {
+            if let Some(tomlfile) = find_cargo_tomlfile(package_source.as_path()) {
+                let package_name = get_package_name(tomlfile.as_path());
+
+                debug!("find_src_via_tomlfile package_name: {}", package_name);
+
+                if package_name == kratename {
+                    return Some(package_source);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn get_local_packages(table: &BTreeMap<String, toml::Value>, cargofile: &Path, section_name: &str) -> Option<Vec<PackageInfo>> {
+    debug!("get_local_packages found table {:?}", table);
+
+    let t = match table.get(section_name) {
         Some(&toml::Value::Table(ref t)) => t,
         _ => return None
     };
 
-    let mut name = kratename;
-    let value = if kratename.contains('_') {
-        t.iter().find(|&(k, _)| k.replace("-", "_") == name).map(|(k,v)| {
-            name = k;
-            v
-        })
-    } else {
-        t.get(kratename)
-    };
+    let mut result = Vec::new();
 
-    match value {
-        Some(&toml::Value::Table(ref t)) => {
-            // local directory
-            let relative_path = otry!(getstr(t, "path"));
-            Some(otry!(cargofile.parent())
-                 .join(relative_path)
-                 .join("src")
-                 .join("lib.rs"))
-        },
-        Some(&toml::Value::String(ref version)) => {
-            // versioned crate
-            get_versioned_cratefile(name, version, cargofile)
-        }
-        _ => None
+    for (package_name, value) in t.iter() {
+        let mut package_version = None;
+
+        let package_source = match *value {
+            toml::Value::Table(ref t) => {
+                // local directory
+                let relative_path = otry!(getstr(t, "path"));
+                Some(otry!(cargofile.parent())
+                    .join(relative_path)
+                    .join("src")
+                    .join("lib.rs"))
+                },
+            toml::Value::String(ref version) => {
+                // versioned crate
+                package_version = Some(version.to_owned());
+                get_versioned_cratefile(package_name, version, cargofile)
+            }
+            _ => continue
+        };
+
+        result.push(PackageInfo {
+            name: package_name.to_owned(),
+            version: package_version,
+            source: package_source
+        });
     }
+    Some(result)
 }
 
 fn find_cratesio_src_dirs(d: PathBuf) -> Vec<PathBuf> {

--- a/src/test_fixtures/Cargo.toml
+++ b/src/test_fixtures/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test_fixtures"
+version = "0.1.0"
+authors = ["jaxx"]
+
+[lib]
+name = "fixtures"
+path = "src/lib.rs"

--- a/src/test_fixtures/src/foo.rs
+++ b/src/test_fixtures/src/foo.rs
@@ -1,0 +1,4 @@
+
+pub fn test() {
+    println!("Hello from test function");
+}

--- a/src/test_fixtures/src/lib.rs
+++ b/src/test_fixtures/src/lib.rs
@@ -1,0 +1,2 @@
+
+pub mod foo;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,4 @@
 extern crate racer;
+
 #[cfg(test)] pub mod system;
 #[cfg(test)] pub mod bench;
-


### PR DESCRIPTION
I tried to fix issue #449. Earlier Racer found package source when crate name was exactly the same as package name - for example if package name was ```rand``` and crate name was ```rand``` then it could navigate to the package source. If package name was ```rust-crypto```, but crate name was ```crypto``` then it couldn't find nothing. So now I made few changes:

1. Racer always iterates over all packages
2. Then finds packages Cargo.toml files
3. Reads package name from toml file (if lib section is present then this comes from lib, else from package section)

I'm kind of a Rust noob, so I think there's a lot room for optimizing this stuff (for example cache those packages in session etc). Also wanted to ask if there's a way to test this?