### PR TITLE
Add URLs to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ version = "1.2.0"
 license = "MIT"
 description = "Code completion for Rust"
 authors = ["Phil Dawes <phil@phildawes.net>"]
+homepage = "https://github.com/phildawes/racer"
+repository = "https://github.com/phildawes/racer"
 
 [lib]
 name = "racer"


### PR DESCRIPTION
This way, the repository (which is also the homepage) will be linked on crates.io.