### PR TITLE
Add RAII helpers TmpDir and TmpFile for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,10 +5,20 @@ dependencies = [
  "clap 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_fixtures 0.1.0",
  "toml 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -77,6 +87,16 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ clap = "~1.5.3"
 
 [dev-dependencies]
 test_fixtures = { path = "src/test_fixtures" }
+rand = "0.3"
 
 [features]
 nightly = []

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1,4 +1,6 @@
+#![deny(warnings)]
 extern crate racer;
+extern crate rand;
 
 use racer::core::complete_from_file;
 use racer::core::find_definition;
@@ -12,19 +14,115 @@ use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::thread;
 
-fn tmpname() -> PathBuf {
+/// A temporary file that is removed on drop
+///
+/// With the new constructor, you provide contents and a file is created based on the name of the
+/// current task. The with_name constructor allows you to choose a name. Neither forms are secure,
+/// and both are subject to race conditions.
+pub struct TmpFile {
+    path_buf: PathBuf
+}
+
+impl TmpFile {
+    /// Create a temp file with random name and `contents`.
+    pub fn new(contents: &str) -> TmpFile {
+        let tmp = TmpFile {
+            path_buf: PathBuf::from(tmpname())
+        };
+
+        tmp.write_contents(contents);
+        tmp
+    }
+
+    /// Create a file with `name` and `contents`.
+    pub fn with_path<P: AsRef<Path>>(name: P, contents: &str) -> TmpFile {
+        let tmp = TmpFile {
+            path_buf: name.as_ref().to_path_buf()
+        };
+
+        tmp.write_contents(contents);
+        tmp
+    }
+
+    /// Create a file with `name` and `contents`.
+    pub fn with_name(name: &str, contents: &str) -> TmpFile {
+        TmpFile::with_path(&Path::new(name), contents)
+    }
+
+    fn write_contents(&self, contents: &str) {
+        let mut f = File::create(self.path()).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        f.flush().unwrap();
+    }
+
+
+    /// Get the Path of the TmpFile
+    pub fn path<'a>(&'a self) -> &'a Path {
+        self.path_buf.as_path()
+    }
+}
+
+/// Make path for tmpfile
+fn tmpname() -> String {
+    use rand::Rng;
+
     let thread = thread::current();
     let taskname = thread.name().unwrap();
     let s = taskname.replace("::", "_");
     let mut p = "tmpfile.".to_string();
     p.push_str(&s[..]);
-    PathBuf::from(p)
+    // Add some random chars
+    for c in ::rand::thread_rng().gen_ascii_chars().take(5) {
+        p.push(c);
+    }
+
+    p
 }
 
-fn write_file(tmppath: &Path, s: &str) {
-    let mut f = File::create(tmppath).unwrap();
-    f.write_all(s.as_bytes()).unwrap();
-    f.flush().unwrap();
+impl Drop for TmpFile {
+    fn drop(&mut self) {
+        fs::remove_file(self.path_buf.as_path()).unwrap();
+    }
+}
+
+pub struct TmpDir {
+    path_buf: PathBuf
+}
+
+impl TmpDir {
+    pub fn new() -> TmpDir {
+        TmpDir::with_name(&tmpname()[..])
+    }
+
+    pub fn with_name(name: &str) -> TmpDir {
+        let pb = PathBuf::from(name);
+        fs::create_dir_all(&pb).unwrap();
+
+        TmpDir {
+            path_buf: pb
+        }
+    }
+
+    /// Create a new temp file in the directory.
+    pub fn new_temp_file(&self, contents: &str) -> TmpFile {
+        self.new_temp_file_with_name(&tmpname()[..], contents)
+    }
+
+    /// Create new temp file with name in the directory
+    pub fn new_temp_file_with_name(&self, name: &str, contents: &str) -> TmpFile {
+        let name = self.path_buf.join(name);
+        TmpFile::with_path(name, contents)
+    }
+
+    pub fn pathbuf(&self) -> &PathBuf {
+        &self.path_buf
+    }
+}
+
+impl Drop for TmpDir {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.path_buf).unwrap();
+    }
 }
 
 #[test]
@@ -36,13 +134,14 @@ fn completes_fn() {
     fn main() {
         let b = ap
     }";
-    let path = tmpname();
-    write_file(&path, src);
+
+    let f = TmpFile::new(src);
+    let path = f.path();
+
     let pos = scopes::coords_to_point(src, 6, 18);
     let cache = core::FileCache::new();
-    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
+    let got = complete_from_file(src, path, pos, &core::Session::from_path(&cache, path, path)).nth(0).unwrap();
 
-    fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
 
@@ -55,15 +154,14 @@ fn completes_fn_with_substitute_file() {
     fn main() {
         let b = ap
     }";
-    let substitute_file = tmpname();
-    write_file(&substitute_file, src);
+
+    let substitute_file = TmpFile::new(src);
     let pos = scopes::coords_to_point(src, 6, 18);
     let cache = core::FileCache::new();
     let real_file = &Path::new("not_real.rs");
-    let session = core::Session::from_path(&cache, &real_file, &substitute_file);
+    let session = core::Session::from_path(&cache, &real_file, substitute_file.path());
     let got = complete_from_file(src, &real_file, pos, &session).nth(0).unwrap();
 
-    fs::remove_file(&substitute_file).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
 
@@ -76,12 +174,11 @@ fn completes_pub_fn_locally() {
     fn main() {
         let b = ap
     }";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 18);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
 
@@ -94,7 +191,8 @@ fn completes_pub_fn_locally_precached() {
     fn main() {
         let b = ap
     }";
-    let path = tmpname();
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 18);
     let cache = core::FileCache::new();
     let session = core::Session::from_path(&cache, &path, &path);
@@ -115,12 +213,11 @@ fn completes_pub_fn_from_local_package() {
     }
     ";
 
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 7, 21);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0);
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.unwrap().matchstr, "test".to_owned());
 }
 
@@ -132,7 +229,7 @@ fn overwriting_cached_files() {
     let src4 = "src4";
 
     // Need session and path to cache files
-    let path = tmpname();
+    let path = &Path::new("not_on_disk");
     let cache = core::FileCache::new();
 
     // Cache contents for a file and assert that load_file and load_file_and_mask_comments return
@@ -162,12 +259,11 @@ fn completes_pub_const_fn_locally() {
     fn main() {
         let b = ap
     }";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 18);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
 
@@ -178,12 +274,11 @@ fn completes_local_scope_let() {
         let apple = 35;
         let b = ap
     }";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 4, 18);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr);
     assert_eq!(29, got.point);
 }
@@ -197,12 +292,11 @@ fn main() {
         let b = ap
     }
 }";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 5, 18);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("apple".to_string(), got.matchstr);
     assert_eq!(25, got.point);
 }
@@ -230,15 +324,14 @@ fn main() { // l16
     t.t
 }
 ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos1 = scopes::coords_to_point(src, 18, 14);  // sub::Foo::
     let cache1 = core::FileCache::new();
     let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0);
     let pos2 = scopes::coords_to_point(src, 19, 7);   // t.t
     let cache2 = core::FileCache::new();
     let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&cache2, &path, &path)).nth(0);
-    fs::remove_file(&path).unwrap();
     println!("{:?}", got1);
     println!("{:?}", got2);
     assert_eq!(got1.unwrap().matchstr, "traitf".to_string());
@@ -258,13 +351,12 @@ fn follows_use() {
         myfn();
     }
     ";
-    write_file(&Path::new("src1.rs"), src1);
-    let path = tmpname();
-    write_file(&path, src);
+    let _f = TmpFile::with_name("src1.rs", src1);
+    let tmp = TmpFile::new(src);
+    let path = tmp.path();
     let pos = scopes::coords_to_point(src, 5, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr,"myfn".to_string());
 }
 
@@ -281,13 +373,12 @@ fn follows_use_as() {
         myfoofn();
     }
     ";
-    write_file(&Path::new("src2.rs"), src2);
-    let path = tmpname();
-    write_file(&path, src);
+    let _f = TmpFile::with_name("src2.rs", src2);
+    let tmp = TmpFile::new(src);
+    let path = tmp.path();
     let pos = scopes::coords_to_point(src, 5, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
 }
 
@@ -304,13 +395,12 @@ fn follows_use_glob() {
         myfn();
     }
     ";
-    write_file(&Path::new("src3.rs"), src3);
-    let path = tmpname();
-    write_file(&path, src);
+    let _f = TmpFile::with_name("src3.rs", src3);
+    let tmp = TmpFile::new(src);
+    let path = tmp.path();
     let pos = scopes::coords_to_point(src, 5, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
 }
 
@@ -322,12 +412,11 @@ fn follows_use_local_package() {
     use fixtures::
     ";
 
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 4, 18);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0);
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.unwrap().matchstr, "foo".to_owned());
 }
 
@@ -342,12 +431,11 @@ fn completes_struct_field_via_assignment() {
     let var = Point {first: 35, second: 22};
     var.f
 ";
-    let path = tmpname();
-    write_file(&path, src);
+    let tmp = TmpFile::new(src);
+    let path = tmp.path();
     let pos = scopes::coords_to_point(src, 8, 9);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("first".to_string(), got.matchstr);
 }
 
@@ -362,12 +450,11 @@ fn finds_defn_of_struct_field() {
     let var = Point {first: 35, second: 22};
     var.first
 ";
-    let path = tmpname();
-    write_file(&path, src);
+    let tmp = TmpFile::new(src);
+    let path = tmp.path();
     let pos = scopes::coords_to_point(src, 8, 9);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "first".to_string());
 }
 
@@ -381,12 +468,11 @@ fn finds_impl_fn() {
 
     Foo::new();
 ";
-    let path = tmpname();
-    write_file(&path, src);
+    let tmp = TmpFile::new(src);
+    let path = tmp.path();
     let pos = scopes::coords_to_point(src, 7, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "new".to_string());
 }
 
@@ -402,12 +488,11 @@ fn follows_use_to_inline_mod() {
         myfn();
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let tmp = TmpFile::new(src);
+    let path = tmp.path();
     let pos = scopes::coords_to_point(src, 8, 9);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
 }
 
@@ -420,13 +505,11 @@ fn finds_enum() {
 
     fn myfn(e: MyEnum) {}
     ";
-    write_file(&Path::new("src.rs"), src);
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 16);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "MyEnum".to_string());
 }
 
@@ -436,13 +519,11 @@ fn finds_type() {
     type SpannedIdent = Spanned<Ident>
     SpannedIdent;
     ";
-    write_file(&Path::new("src.rs"), src);
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 5);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "SpannedIdent".to_string());
 }
 
@@ -452,13 +533,11 @@ fn finds_trait() {
     pub trait MyTrait<E: Clone> {}
     MyTrait
     ";
-    write_file(&Path::new("src.rs"), src);
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 5);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "MyTrait".to_string());
 }
 
@@ -470,13 +549,11 @@ fn finds_macro() {
     }
     my_macro!();
     ";
-    write_file(&Path::new("src.rs"), src);
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 5, 5);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "my_macro!".to_string());
 }
 
@@ -487,13 +564,11 @@ fn finds_fn_arg() {
          myarg
     }
     ";
-    write_file(&Path::new("src.rs"), src);
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myarg".to_string());
 }
 
@@ -503,13 +578,11 @@ fn finds_fn_arg_in_incomplete_fn() {
     fn myfn(myarg: &str) {
          myarg
     ";
-    write_file(&Path::new("src.rs"), src);
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "myarg".to_string());
 }
 
@@ -522,13 +595,11 @@ fn finds_inline_fn() {
 
     contains();
     ";
-    write_file(&Path::new("src.rs"), src);
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 9);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "contains".to_string());
 }
 
@@ -550,20 +621,19 @@ fn follows_self_use() {
         myfn();
     }
     ";
-    let basedir = tmpname();
-    let moddir = basedir.join("mymod");
-    fs::create_dir_all(&moddir).unwrap();
 
-    write_file(&moddir.join("mod.rs"), modsrc);
-    write_file(&moddir.join("src4.rs"), src4);
-    let srcpath = basedir.join("src.rs");
-    write_file(&srcpath, src);
+    let mymod = TmpDir::with_name("mymod");
+    let _modrs = mymod.new_temp_file_with_name("mod.rs", modsrc);
+    let _src4 = mymod.new_temp_file_with_name("src4.rs", src4);
+
+    let src_file = TmpFile::with_name("src.rs", src);
+    let srcpath = src_file.path();
+
     let pos = scopes::coords_to_point(src, 6, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath)).unwrap();
-    fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
-    assert_eq!(moddir.join("src4.rs").display().to_string(),
+    assert_eq!(mymod.pathbuf().join("src4.rs").display().to_string(),
                got.filepath.display().to_string());
     assert_eq!(28, got.point);
 }
@@ -583,16 +653,17 @@ fn finds_nested_submodule_file() {
     pub fn myfn() {}
     ";
 
-    let basedir = tmpname();
+    let basedir = PathBuf::from(tmpname());
     let srcpath = basedir.join("root.rs");
     let sub2dir = basedir.join("sub1").join("sub2");
-    fs::create_dir_all(&sub2dir).unwrap();
-    write_file(&srcpath, rootsrc);
-    write_file(&sub2dir.join("sub3.rs"), sub3src);
+    let _dir = TmpDir::with_name(sub2dir.as_path().to_str().unwrap());
+
+    let _src = TmpFile::with_path(&srcpath, rootsrc);
+    let _src3 = TmpFile::with_path(&sub2dir.join("sub3.rs"), sub3src);
+
     let pos = scopes::coords_to_point(rootsrc, 7, 23);
     let cache = core::FileCache::new();
     let got = find_definition(rootsrc, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath)).unwrap();
-    fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got.matchstr, "myfn".to_string());
     assert_eq!(sub2dir.join("sub3.rs").display().to_string(),
                got.filepath.display().to_string());
@@ -604,12 +675,11 @@ fn follows_super_in_sub_module() {
     pub fn iamhere() { }
     mod inner { pub use super::iamhere; }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 33);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("iamhere", got.matchstr);
 }
 
@@ -621,12 +691,11 @@ fn follows_super_in_local_sub_module() {
       mod inner2 { pub use super::iamhere; }
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 4, 38);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("iamhere", got.matchstr);
 }
 
@@ -647,21 +716,18 @@ fn follows_use_to_impl() {
         Foo::new();
     }
     ";
-    let basedir = tmpname();
-    fs::create_dir(&basedir).unwrap();
+    let dir = TmpDir::with_name("tmp");
+    let mod_file = dir.new_temp_file_with_name("mymod.rs", modsrc);
+    let src_file = dir.new_temp_file_with_name("src.rs", src);
+    let srcpath = src_file.path();
 
-    let modpath = basedir.join("mymod.rs");
-    write_file(&modpath, modsrc);
-    let srcpath = basedir.join("src.rs");
-    write_file(&srcpath, src);
     let pos = scopes::coords_to_point(src, 5, 14);
     let cache = core::FileCache::new();
     let got = find_definition(src, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath)).unwrap();
 
-    fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got.matchstr, "new".to_string());
     assert_eq!(90, got.point);
-    assert_eq!(modpath.display().to_string(),
+    assert_eq!(mod_file.path().display().to_string(),
                got.filepath.display().to_string());
 }
 
@@ -675,12 +741,11 @@ fn finds_templated_impl_fn() {
 
     Foo::new();
 ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 7, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "new".to_string());
 }
 
@@ -698,12 +763,11 @@ fn follows_fn_to_method() {
         v.my
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 10, 12);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
 }
 
@@ -719,12 +783,11 @@ fn follows_arg_to_method() {
         v.my
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 8, 12);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
 }
 
@@ -742,12 +805,11 @@ fn follows_arg_to_enum_method() {
         v.my
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 10, 12);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
 }
 
@@ -768,12 +830,11 @@ fn follows_let_method_call() {
         f.my
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 13, 12);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("mybarmethod".to_string(), got.matchstr);
 }
 
@@ -793,12 +854,11 @@ fn follows_chained_method_call() {
         v.mymethod().my
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 12, 23);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("mybarmethod".to_string(), got.matchstr);
 }
 
@@ -817,12 +877,11 @@ fn discards_inner_fns() {
         v.i
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 11, 11);
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0);
-    fs::remove_file(&path).unwrap();
     assert!(got.is_none(), "should not match inner function");
 }
 
@@ -834,12 +893,11 @@ fn differentiates_type_and_value_namespaces() {
     impl Foo { pub fn new() -> Foo {} }
     let l = Foo::new();
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 5, 18);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     println!("{}", got.matchstr);
     println!("{:?}", got.mtype);
     assert_eq!("new", got.matchstr);
@@ -857,12 +915,11 @@ fn follows_self_to_method() {
             self.method()
         }
     }";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 8, 20);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("method", got.matchstr);
 }
 
@@ -880,12 +937,11 @@ fn follows_self_to_method_when_call_on_new_line() {
                 .method()
         }
     }";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 9, 20);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("method", got.matchstr);
 }
 
@@ -899,12 +955,11 @@ fn follows_self_to_trait_method() {
             self.method()
         }
     }";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 20);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("method", got.matchstr);
 }
 
@@ -922,12 +977,11 @@ fn finds_trait_method() {
             self.trait_method();
         }
     }";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 10, 22);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("trait_method", got.matchstr);
 }
 
@@ -943,12 +997,11 @@ fn finds_field_type() {
     let f = Foo{ myfield: Blah { subfield: 3}};
     f.myfield.subfield
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 9, 16);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -962,12 +1015,11 @@ fn finds_a_generic_retval_from_a_function() {
     fn myfn() -> Foo<Blah> {}
     myfn().myfield.subfield
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 7, 24);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -986,12 +1038,11 @@ fn handles_an_enum_option_style_return_type() {
     let s = myfn();
     s.unwrap().subfield
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 12, 18);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1001,12 +1052,11 @@ fn finds_definition_of_const() {
     pub const MYCONST:uint = 3;
     MYCONST
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 7);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("MYCONST", got.matchstr);
 }
 
@@ -1016,12 +1066,11 @@ fn finds_definition_of_static() {
     pub static MYSTATIC:uint = 3;
     MYSTATIC
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 7);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("MYSTATIC", got.matchstr);
 }
 
@@ -1031,12 +1080,11 @@ fn handles_dotdot_before_searchstr() {
     static MYLEN:uint = 30;
     let f = [0i32, ..MYLEN];
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 22);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("MYLEN", got.matchstr);
 }
 
@@ -1047,12 +1095,11 @@ fn finds_definition_of_lambda_argument() {
     fn myfn(&|int|) {}
     myfn(|a|a+3);
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 12);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
 
@@ -1062,12 +1109,11 @@ fn finds_definition_of_let_tuple() {
     let (a, b) = (2,3);
     a
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 4);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
 
@@ -1078,12 +1124,11 @@ fn finds_type_of_tuple_member_via_let_type() {
     let (a, b): (uint, Blah);
     b.subfield
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 4, 11);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1094,12 +1139,11 @@ fn finds_type_of_tuple_member_via_let_expr() {
     let (a, b) = (3, Blah{subfield:3});
     b.subfield
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 4, 11);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1111,12 +1155,11 @@ fn finds_type_of_tuple_member_via_fn_retval() {
     let (a, b) = myfn();
     b.subfield
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 5, 11);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1128,12 +1171,11 @@ fn finds_type_of_tuple_member_in_fn_arg() {
         c.subfield
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 4, 11);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1143,12 +1185,11 @@ fn finds_namespaced_enum_variant() {
     pub enum Blah { MyVariant }
     Blah::MyVariant
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 14);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("MyVariant", got.matchstr);
 }
 
@@ -1159,12 +1200,11 @@ fn finds_glob_imported_enum_variant() {
     pub enum Blah { MyVariant, MyVariant2 }
     MyVariant
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 4, 8);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("MyVariant", got.matchstr);
 }
 
@@ -1179,12 +1219,11 @@ fn uses_generic_arg_to_resolve_trait_method() {
         T.trait_method
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 19);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("trait_method", got.matchstr);
 }
 
@@ -1196,12 +1235,11 @@ fn destructures_a_tuplestruct() {
     let TupleStruct(var) = TupleStruct(Blah{subfield:35});
     var.subfield
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 5, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1214,12 +1252,11 @@ fn destructures_a_tuplestruct_with_generic_arg() {
     let TupleStruct(var) = a;
     var.subfield
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1230,13 +1267,12 @@ fn finds_if_let_ident_defn() {
         myvar
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 13);
     let cache = core::FileCache::new();
     let mut it = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path));
     let got = it.next().unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("myvar", &*got.matchstr);
     assert!(it.next().is_none(), "should only match the first one");
 }
@@ -1250,12 +1286,11 @@ fn doesnt_find_if_let_if_not_in_the_subscope() {
     }
     myvar
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 6);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("myvar", &*got.matchstr);
     assert_eq!(9, got.point);
 }
@@ -1268,12 +1303,11 @@ fn finds_rebound_var_in_iflet() {
         o
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 4, 8);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(56, got.point);
 }
 
@@ -1290,12 +1324,11 @@ fn handles_if_let() {
         a.subfield
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 9, 13);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1312,12 +1345,11 @@ fn handles_if_let_as_expression() {
         a.subfield
     };
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 9, 13);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1327,12 +1359,11 @@ fn finds_match_arm_var() {
     match foo {
        Some(a) => a
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 18);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
 
@@ -1342,12 +1373,11 @@ fn finds_match_arm_var_in_scope() {
     match foo {
        Some(a) => { a }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 20);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
 
@@ -1362,12 +1392,11 @@ fn finds_match_arm_enum() {
        MyEnum::Foo => 1,
        MyEnum::Bar => 2
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 7, 18);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("Foo", got.matchstr);
 }
 
@@ -1383,12 +1412,11 @@ fn finds_match_arm_var_with_nested_match() {
                a
        }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 8, 15);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
 }
 
@@ -1404,12 +1432,11 @@ fn gets_type_via_match_arm() {
     match o {
         MyOption::MySome(a) => a.subfield
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 9, 38);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("subfield", got.matchstr);
 }
 
@@ -1422,12 +1449,11 @@ fn handles_default_arm() {
         _ => o
     }
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 5, 13);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("o", got.matchstr);
     assert_eq!(9, got.point);
 }
@@ -1438,12 +1464,11 @@ fn doesnt_match_rhs_of_let_in_same_stmt() {
     let a = 3;      // <--- should match this 'a'
     let a = a + 2;  // not this one
     ";
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 3, 12);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!("a", got.matchstr);
     assert_eq!(9, got.point);
 }
@@ -1463,13 +1488,11 @@ fn finds_unsafe_fn() {
         foo()
     }
     ";
-    write_file(&Path::new("src.rs"), src);
-    let path = tmpname();
-    write_file(&path, src);
+    let f = TmpFile::new(src);
+    let path = f.path();
     let pos = scopes::coords_to_point(src, 5, 9);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    fs::remove_file(&path).unwrap();
     assert_eq!(got.matchstr, "foo".to_string());
     assert_eq!(got.point, 15);
 }
@@ -1511,22 +1534,19 @@ fn completes_methods_on_deref_type() {
         b.o
     }
     ";
-    let basedir = tmpname();
-    fs::create_dir(&basedir).unwrap();
 
-    let modpath = basedir.join("mymod.rs");
-    write_file(&modpath, modsrc);
-    let srcpath = basedir.join("src.rs");
-    write_file(&srcpath, src);
+    let dir = TmpDir::new();
+
+    let _modfile = dir.new_temp_file_with_name("mymod.rs", modsrc);
+    let srcfile = dir.new_temp_file_with_name("src.rs", src);
+    let srcpath = srcfile.path();
+
     let pos = scopes::coords_to_point(src, 7, 11);
     let cache = core::FileCache::new();
 
-    let got_str = match complete_from_file(src, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath)).nth(0) {
-        Some(m) => m.matchstr,
-        None => {fs::remove_dir_all(&basedir).unwrap(); return panic!("No match found!");}
-    };
+    let got_str = complete_from_file(src, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath))
+                                    .nth(0).expect("No match found").matchstr;
 
-    fs::remove_dir_all(&basedir).unwrap();
     assert_eq!(got_str, "one".to_string());
 }
 
@@ -1567,21 +1587,15 @@ fn completes_methods_on_deref_generic_type() {
         b.o
     }
     ";
-    let basedir = tmpname();
-    fs::create_dir(&basedir).unwrap();
+    let dir = TmpDir::new();
+    let _modfile = dir.new_temp_file_with_name("mymod.rs", modsrc);
+    let srcfile = dir.new_temp_file_with_name("src.rs", src);
+    let srcpath = srcfile.path();
 
-    let modpath = basedir.join("mymod.rs");
-    write_file(&modpath, modsrc);
-    let srcpath = basedir.join("src.rs");
-    write_file(&srcpath, src);
     let pos = scopes::coords_to_point(src, 7, 11);
     let cache = core::FileCache::new();
 
-    let got_str = match complete_from_file(src, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath)).nth(0) {
-        Some(m) => m.matchstr,
-        None => {fs::remove_dir_all(&basedir).unwrap(); return panic!("No match found!");}
-    };
-
-    fs::remove_dir_all(&basedir).unwrap();
+    let got_str = complete_from_file(src, &srcpath, pos, &core::Session::from_path(&cache, &srcpath, &srcpath))
+                                    .nth(0).expect("No match found").matchstr;
     assert_eq!(got_str, "one".to_string());
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,5 @@
 extern crate racer;
+extern crate rand;
 
 #[cfg(test)] pub mod system;
 #[cfg(test)] pub mod bench;


### PR DESCRIPTION
Tests in system.rs previously managed creating a temporary name, writing a file, and removing it. The steps associated with creating and removing these files and directories is now abstracted from test writers. Additionally, since these types have Drop impls for cleanup, the files and directories they manage will be removed even on test failure.

The rand crate was added to add some entropy to test names to reduce the probability of name collisions.