### PR TITLE
 Remove unsafe code regarding arena allocations in the cache

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -29,7 +29,7 @@ use std::io::{self, BufRead};
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 #[cfg(not(test))]
-fn match_with_snippet_fn(m: Match, session: &core::Session, interface: Interface) {
+fn match_with_snippet_fn(m: Match, session: core::SessionRef, interface: Interface) {
     let (linenum, charnum) = scopes::point_to_coords_from_file(&m.filepath, m.point, session).unwrap();
     if m.matchstr == "" {
         panic!("MATCHSTR is empty - waddup?");
@@ -59,7 +59,7 @@ fn match_with_snippet_fn(m: Match, session: &core::Session, interface: Interface
 }
 
 #[cfg(not(test))]
-fn match_fn(m: Match, session: &core::Session, interface: Interface) {
+fn match_fn(m: Match, session: core::SessionRef, interface: Interface) {
     if let Some((linenum, charnum)) = scopes::point_to_coords_from_file(&m.filepath,
                                                                         m.point,
                                                                         session) {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -120,7 +120,7 @@ enum CompletePrinter {
 }
 
 #[cfg(not(test))]
-fn cache_file_contents_from_stdin<'a>(file: &PathBuf, cache: &'a core::FileCache<'a>) {
+fn cache_file_contents_from_stdin(file: &PathBuf, cache: &mut core::FileCache) {
     let stdin = io::stdin();
 
     let mut rawbytes = Vec::new();
@@ -135,12 +135,11 @@ fn run_the_complete_fn(cfg: &Config, print_type: CompletePrinter) {
     let fn_path = &*cfg.fn_name.as_ref().unwrap();
     let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
 
-    let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, fn_path, substitute_file);
-
+    let mut cache = core::FileCache::new();
     if substitute_file.to_str() == Some("-") {
-        cache_file_contents_from_stdin(&substitute_file, &cache);
+        cache_file_contents_from_stdin(&substitute_file, &mut cache);
     }
+    let session = core::Session::from_path(cache, fn_path, substitute_file);
 
     let src = session.load_file(fn_path);
     let line = &getline(substitute_file, cfg.linenum, &session);
@@ -169,7 +168,7 @@ fn external_complete(cfg: Config) {
     let p: Vec<&str> = cfg.fqn.as_ref().unwrap().split("::").collect();
     let cwd = Path::new(".");
     let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, &cwd, &cwd);
+    let session = core::Session::from_path(cache, &cwd, &cwd);
 
     for m in do_file_search(p[0], &Path::new(".")) {
         if p.len() == 1 {
@@ -188,12 +187,11 @@ fn external_complete(cfg: Config) {
 fn prefix(cfg: Config) {
     let fn_path = &*cfg.fn_name.as_ref().unwrap();
     let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
-    let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, fn_path, substitute_file);
-
+    let mut cache = core::FileCache::new();
     if substitute_file.to_str() == Some("-") {
-        cache_file_contents_from_stdin(&substitute_file, &cache);
+        cache_file_contents_from_stdin(&substitute_file, &mut cache);
     }
+    let session = core::Session::from_path(cache, fn_path, substitute_file);
 
     // print the start, end, and the identifier prefix being matched
     let line = &getline(fn_path, cfg.linenum, &session);
@@ -210,12 +208,11 @@ fn prefix(cfg: Config) {
 fn find_definition(cfg: Config) {
     let fn_path = &*cfg.fn_name.as_ref().unwrap();
     let substitute_file = cfg.substitute_file.as_ref().unwrap_or(fn_path);
-    let cache = core::FileCache::new();
-    let session = core::Session::from_path(&cache, fn_path, substitute_file);
-
+    let mut cache = core::FileCache::new();
     if substitute_file.to_str() == Some("-") {
-        cache_file_contents_from_stdin(&substitute_file, &cache);
+        cache_file_contents_from_stdin(&substitute_file, &mut cache);
     }
+    let session = core::Session::from_path(cache, fn_path, substitute_file);
 
     let src = session.load_file(fn_path);
     let pos = scopes::coords_to_point(&src, cfg.linenum, cfg.charnum);

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -254,15 +254,15 @@ fn destructure_pattern_to_ty(pat: &ast::Pat,
     }
 }
 
-struct LetTypeVisitor<'c: 's, 's> {
+struct LetTypeVisitor<'c> {
     scope: Scope,
-    session: SessionRef<'c, 's>,
+    session: SessionRef<'c>,
     srctxt: String,
     pos: usize,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
 }
 
-impl<'c, 's, 'v> visit::Visitor<'v> for LetTypeVisitor<'c, 's> {
+impl<'c, 'v> visit::Visitor<'v> for LetTypeVisitor<'c> {
     fn visit_expr(&mut self, ex: &'v ast::Expr) {
         match ex.node {
             ast::ExprIfLet(ref pattern, ref expr, _, _) |
@@ -304,14 +304,14 @@ impl<'c, 's, 'v> visit::Visitor<'v> for LetTypeVisitor<'c, 's> {
     }
 }
 
-struct MatchTypeVisitor<'c: 's, 's> {
+struct MatchTypeVisitor<'c> {
     scope: Scope,
-    session: SessionRef<'c, 's>,
+    session: SessionRef<'c>,
     pos: usize,        // pos is relative to the srctxt, scope is global
     result: Option<Ty>
 }
 
-impl<'c, 's, 'v> visit::Visitor<'v> for MatchTypeVisitor<'c, 's> {
+impl<'c, 'v> visit::Visitor<'v> for MatchTypeVisitor<'c> {
     fn visit_expr(&mut self, ex: &'v ast::Expr) {
         if let ast::ExprMatch(ref subexpression, ref arms) = ex.node {
             debug!("PHIL sub expr is {:?}", subexpression);
@@ -412,13 +412,13 @@ fn get_type_of_typedef(m: Match, session: SessionRef) -> Option<Match> {
 }
 
 
-struct ExprTypeVisitor<'c: 's, 's> {
+struct ExprTypeVisitor<'c> {
     scope: Scope,
-    session: SessionRef<'c, 's>,
+    session: SessionRef<'c>,
     result: Option<Ty>,
 }
 
-impl<'c, 's, 'v> visit::Visitor<'v> for ExprTypeVisitor<'c, 's> {
+impl<'c, 'v> visit::Visitor<'v> for ExprTypeVisitor<'c> {
     fn visit_expr(&mut self, expr: &ast::Expr) {
         debug!("visit_expr {:?}", expr);
         //walk_expr(self, ex, e)
@@ -976,14 +976,14 @@ impl<'v> visit::Visitor<'v> for FnOutputVisitor {
     }
 }
 
-pub struct FnArgTypeVisitor<'c: 's, 's> {
+pub struct FnArgTypeVisitor<'c> {
     argpos: usize,
     scope: Scope,
-    session: SessionRef<'c, 's>,
+    session: SessionRef<'c>,
     pub result: Option<Ty>
 }
 
-impl<'c, 's, 'v> visit::Visitor<'v> for FnArgTypeVisitor<'c, 's> {
+impl<'c, 'v> visit::Visitor<'v> for FnArgTypeVisitor<'c> {
     fn visit_fn(&mut self, _: visit::FnKind, fd: &ast::FnDecl, _: &ast::Block, _: codemap::Span, _: ast::NodeId) {
         for arg in &fd.inputs {
             let codemap::BytePos(lo) = arg.pat.span.lo;

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -333,132 +333,90 @@ pub fn new_source(src: String) -> IndexedSource {
     IndexedSource::new(src)
 }
 
-pub struct FileCache<'c> {
-    /// provides allocations
-    arena: Arena<IndexedSource>,
-    /// active references to raw source
-    raw_map: RefCell<HashMap<path::PathBuf, &'c IndexedSource>>,
-    /// active references to masked source
-    masked_map: RefCell<HashMap<path::PathBuf, &'c IndexedSource>>,
-    /// allocations that should be used before allocating from the arena.
-    allocations_available: RefCell<Vec<&'c mut IndexedSource>>,
-    /// allocations that have been freed in the current generation.
-    allocations_freed: RefCell<Vec<&'c IndexedSource>>,
+pub struct FileCache {
+    /// raw source for cached files
+    raw_map: HashMap<path::PathBuf, IndexedSource>,
+    /// masked source for cached files
+    masked_map: HashMap<path::PathBuf, IndexedSource>,
 }
 
-impl<'c> FileCache<'c> {
-    pub fn new<'a>() -> FileCache<'a> {
+/// Caches file contents for re-use between sessions.
+///
+/// There are two versions of each file that can be cached indepdendently:
+/// "raw" and "masked", where "masked" is a version with comments and
+/// strings replaced by spaces, so that they aren't found when scanning
+/// the source for signatures.
+impl FileCache {
+    pub fn new() -> FileCache {
         FileCache {
+            raw_map: HashMap::new(),
+            masked_map: HashMap::new(),
+        }
+    }
+
+    /// Add/Replace a file in both versions.
+    pub fn cache_file_contents<T>(&mut self, filepath: &path::Path, buf: T)
+        where T: Into<String>
+    {
+        let src = IndexedSource::new(buf.into());
+        let masked_src = IndexedSource::new(scopes::mask_comments(src.as_ref()));
+        self.raw_map.insert(filepath.to_path_buf(), src);
+        self.masked_map.insert(filepath.to_path_buf(), masked_src);
+    }
+}
+
+/// Version of FileCache that is used while a Session is active.
+///
+/// The need for separate types is due to several requirements:
+///
+/// - we have to add files to the cache during completion, so the
+///   cache has to be at least internally mutable (RefCells)
+///
+/// - that the racer core methods use references to source strings
+///   all over the place, so we can't use references tied to RefCell
+///   borrow lifetimes
+///
+/// These two requirements make the use of a scheme like the Arena in
+/// this type necessary: it provides a lifetime that is long enough
+/// (lifetime of the session), and the hash-map RefCells only need to
+/// store references to its contents.
+///
+/// However, there is one more requirement:
+///
+/// - the file cache should be long-lived (a Session is one completion
+///   run, but if racer runs as a daemon the cache will remain)
+///
+/// This makes the Arena-RefCell cache unsuitable, because there is no
+/// way to free now-unused but still allocated source strings.
+///
+/// The two-layer allows append-only allocation during Session run, but
+/// when the session is finished (with `destroy`) the long lived cache
+/// is updated with all new entries from the short lived cache.
+///
+/// This should also make it possible to share the long lived cache
+/// among threads, if that would be desired at one point.
+pub struct SessionFileCache<'c> {
+    base: FileCache,
+    arena: Arena<(bool, path::PathBuf, IndexedSource)>,
+    raw_map: RefCell<HashMap<&'c path::Path, &'c IndexedSource>>,
+    masked_map: RefCell<HashMap<&'c path::Path, &'c IndexedSource>>,
+}
+
+impl<'c> SessionFileCache<'c> {
+    pub fn new<'a>(base: FileCache) -> SessionFileCache<'a> {
+        SessionFileCache {
+            base: base,
             arena: Arena::new(),
             raw_map: RefCell::new(HashMap::new()),
             masked_map: RefCell::new(HashMap::new()),
-            allocations_available: RefCell::new(Vec::new()),
-            allocations_freed: RefCell::new(Vec::new()),
         }
     }
 
-    /// Updates available allocations from recently freed lists
-    ///
-    /// While a session is active, allocations may be marked as freed. Reusing the allocation while
-    /// references could still be active would have unintended consequences.
-    ///
-    /// # Safety
-    ///
-    /// The FileCache must not have references handed out at the time this is called. Since the
-    /// FileCache is only accessed by the Session, it is save to call this when the Session is
-    /// dropped. Actually, it is called by the Session drop impl, and it shouldn't need to be called
-    /// at any other time.
-    pub unsafe fn update_available_allocations(&self) {
-        let mut freed = self.allocations_freed.borrow_mut();
-        let mut available = self.allocations_available.borrow_mut();
-
-        while let Some(alloc) = freed.pop() {
-            // Add a mutable reference to the available allocation list
-            let ptr = ::std::mem::transmute::<*const IndexedSource, *mut IndexedSource>(alloc);
-            available.push(&mut *ptr);
-        }
-    }
-
-    /// Checks if allocations are available
-    #[inline]
-    fn needs_alloc(&self) -> bool {
-        self.allocations_available.borrow().len() == 0
-    }
-
-    /// Allocate an IndexedSource using provided value.
-    ///
-    /// Attempts to reuse a freed allocation before allocating from arena.
-    ///
-    /// If the contract about freed allocations is not upheld, this could result in undefined
-    /// behavior.
-    ///
-    /// TODO should this be marked unsafe until it can be refactored into a safer api?
-    fn alloc(&self, value: IndexedSource) -> &mut IndexedSource {
-        if self.needs_alloc() {
-            // new alloc
-            self.arena.alloc(value)
-        } else {
-            // reuse freed alloc
-            unsafe {
-                // Get a mutable reference to the old object
-                let ptr: *mut IndexedSource = self.allocations_available.borrow_mut().pop().unwrap();
-
-                // Run drop for the previously stored value. This has to be done when the allocation
-                // is being reused so that the memory is always intialized to valid values.
-                ::std::mem::drop(::std::ptr::read(ptr));
-
-                // copy provided value into ptr without running drop
-                ::std::ptr::write(ptr, value);
-
-                // A reference to the updated allocation is returned.
-                &mut *ptr
-            }
-        }
-    }
-
-
-    /// Cache the contents of `buf` using the given `Path` for a key.
-    ///
-    /// Subsequent calls to load_file will return an IndexedSource of the provided buf.
-    pub fn cache_file_contents<T>(&'c self, filepath: &path::Path, buf: T)
-    where T: Into<String> {
-        // update raw file
-        {
-            let mut cache = self.raw_map.borrow_mut();
-
-            // Mark previous allocation free
-            if let Some(prev) = cache.get(filepath) {
-                self.allocations_freed.borrow_mut().push(prev);
-            }
-
-            cache.insert(filepath.to_path_buf(), {
-                self.alloc(IndexedSource::new(buf.into()))
-            });
-        }
-
-        // also need to update masked version
-        {
-            // TODO stash old version in free list
-            let mut cache = self.masked_map.borrow_mut();
-
-            if let Some(prev) = cache.get(filepath) {
-                self.allocations_freed.borrow_mut().push(prev);
-            }
-
-            cache.insert(filepath.to_path_buf(), {
-                let src = self.load_file(filepath);
-
-                // create a new IndexedSource with new source, but same indices
-                self.alloc(src.src.with_src(scopes::mask_comments(src)))
-            });
-        }
-    }
-
-    pub fn open_file(&self, path: &path::Path) -> io::Result<File> {
+    fn open_file(&self, path: &path::Path) -> io::Result<File> {
         File::open(path)
     }
 
-    pub fn read_file(&self, path: &path::Path) -> Vec<u8> {
+    fn read_file(&self, path: &path::Path) -> Vec<u8> {
         let mut rawbytes = Vec::new();
         if let Ok(mut f) = self.open_file(path) {
             f.read_to_end(&mut rawbytes).unwrap();
@@ -476,38 +434,46 @@ impl<'c> FileCache<'c> {
         }
     }
 
-    pub fn load_file(&'c self, filepath: &path::Path) -> Src<'c> {
-        let mut cache = self.raw_map.borrow_mut();
-        cache.entry(filepath.to_path_buf()).or_insert_with(|| {
-            let rawbytes = self.read_file(filepath);
-            let res = String::from_utf8(rawbytes).unwrap();
-            self.alloc(IndexedSource::new(res))
-        }).as_ref()
+    pub fn load_file<'s: 'c>(&'s self, filepath: &path::Path) -> Src<'c> {
+        if let Some(src) = self.raw_map.borrow().get(filepath) {
+            return src.as_ref();
+        }
+        if let Some(src) = self.base.raw_map.get(filepath) {
+            return src.as_ref();
+        }
+        // nothing found, insert into cache
+        let rawbytes = self.read_file(filepath);
+        let res = String::from_utf8(rawbytes).unwrap();
+        let alloc = self.arena.alloc((false, filepath.to_path_buf(),
+                                      IndexedSource::new(res)));
+        self.raw_map.borrow_mut().insert(&alloc.1, &alloc.2);
+        alloc.2.as_ref()
     }
 
-    pub fn load_file_and_mask_comments(&'c self, filepath: &path::Path) -> Src<'c> {
-        let mut cache = self.masked_map.borrow_mut();
-        cache.entry(filepath.to_path_buf()).or_insert_with(|| {
-            let src = self.load_file(filepath);
-            // create a new IndexedSource with new source, but same indices
-            self.alloc(src.src.with_src(scopes::mask_comments(src)))
-        }).as_ref()
+    pub fn load_file_and_mask_comments<'s: 'c>(&'s self, filepath: &path::Path) -> Src<'c> {
+        if let Some(src) = self.masked_map.borrow().get(filepath) {
+            return src.as_ref();
+        }
+        if let Some(src) = self.base.masked_map.get(filepath) {
+            return src.as_ref();
+        }
+        // nothing found, insert into cache
+        let src = self.load_file(filepath);
+        let alloc = self.arena.alloc((true, filepath.to_path_buf(),
+                                      src.src.with_src(scopes::mask_comments(src))));
+        self.masked_map.borrow_mut().insert(&alloc.1, &alloc.2);
+        alloc.2.as_ref()
     }
 }
 
 pub struct Session<'c> {
     query_path: path::PathBuf,            // the input path of the query
     substitute_file: path::PathBuf,       // the temporary file
-    cache: &'c FileCache<'c>              // cache for file contents
+    cache: SessionFileCache<'c>,          // cache for file contents
 }
 
-pub type SessionRef<'c, 's> = &'s Session<'c>;
+pub type SessionRef<'c> = &'c Session<'c>;
 
-impl<'a> Drop for Session<'a> {
-    fn drop(&mut self) {
-        unsafe { self.cache.update_available_allocations(); }
-    }
-}
 
 impl<'c> fmt::Debug for Session<'c> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -516,14 +482,26 @@ impl<'c> fmt::Debug for Session<'c> {
 }
 
 impl<'c> Session<'c> {
-    pub fn from_path(cache: &'c FileCache<'c>,
+    pub fn from_path(cache: FileCache,
                      query_path: &path::Path,
                      substitute_file: &path::Path) -> Session<'c> {
         Session {
             query_path: query_path.to_path_buf(),
             substitute_file: substitute_file.to_path_buf(),
-            cache: cache
+            cache: SessionFileCache::new(cache),
         }
+    }
+
+    /// Transfer allocated cache entries to the long lived cache and return it.
+    pub fn destroy(mut self) -> FileCache {
+        for (masked, filepath, src) in self.cache.arena.into_vec() {
+            if masked {
+                self.cache.base.masked_map.insert(filepath, src);
+            } else {
+                self.cache.base.raw_map.insert(filepath, src);
+            }
+        }
+        self.cache.base
     }
 
     /// Resolve appropriate path for current query
@@ -537,30 +515,17 @@ impl<'c> Session<'c> {
         }
     }
 
-    pub fn cache_file_contents<T>(&self, filepath: &path::Path, buf: T)
-    where T: Into<String> {
-        self.cache.cache_file_contents(filepath, buf);
-    }
-
-    pub fn open_file(&self, path: &path::Path) -> io::Result<File> {
-        self.cache.open_file(self.resolve_path(path))
-    }
-
-    pub fn read_file(&self, path: &path::Path) -> Vec<u8> {
-        self.cache.read_file(self.resolve_path(path))
-    }
-
-    pub fn load_file(&self, filepath: &path::Path) -> Src<'c> {
+    pub fn load_file(&'c self, filepath: &path::Path) -> Src<'c> {
         self.cache.load_file(self.resolve_path(filepath))
     }
 
-    pub fn load_file_and_mask_comments(&self, filepath: &path::Path) -> Src<'c> {
+    pub fn load_file_and_mask_comments(&'c self, filepath: &path::Path) -> Src<'c> {
         self.cache.load_file_and_mask_comments(self.resolve_path(filepath))
     }
 }
 
 
-pub fn complete_from_file(src: &str, filepath: &path::Path, 
+pub fn complete_from_file(src: &str, filepath: &path::Path,
                           pos: usize, session: SessionRef) -> vec::IntoIter<Match> {
     let start = scopes::get_start_of_search_expr(src, pos);
     let expr = &src[start..pos];

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -501,6 +501,7 @@ pub struct Session<'c> {
     cache: &'c FileCache<'c>              // cache for file contents
 }
 
+pub type SessionRef<'c, 's> = &'s Session<'c>;
 
 impl<'a> Drop for Session<'a> {
     fn drop(&mut self) {
@@ -560,7 +561,7 @@ impl<'c> Session<'c> {
 
 
 pub fn complete_from_file(src: &str, filepath: &path::Path, 
-                          pos: usize, session: &Session) -> vec::IntoIter<Match> {
+                          pos: usize, session: SessionRef) -> vec::IntoIter<Match> {
     let start = scopes::get_start_of_search_expr(src, pos);
     let expr = &src[start..pos];
 
@@ -601,11 +602,11 @@ pub fn complete_from_file(src: &str, filepath: &path::Path,
     out.into_iter()
 }
 
-pub fn find_definition(src: &str, filepath: &path::Path, pos: usize, session: &Session) -> Option<Match> {
+pub fn find_definition(src: &str, filepath: &path::Path, pos: usize, session: SessionRef) -> Option<Match> {
     find_definition_(src, filepath, pos, session)
 }
 
-pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: &Session) -> Option<Match> {
+pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: SessionRef) -> Option<Match> {
     let (start, end) = scopes::expand_search_expr(src, pos);
     let expr = &src[start..end];
 

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -1,5 +1,5 @@
 use {scopes, typeinf, ast};
-use core::{Match, PathSegment, Src, Session};
+use core::{Match, PathSegment, Src, SessionRef};
 use util::{symbol_matches, txt_matches, find_ident_end, is_ident_char, char_at};
 use nameres::{get_module_file, get_crate_file, resolve_path};
 use core::SearchType::{self, StartsWith, ExactMatch};
@@ -17,7 +17,7 @@ pub type MChain<T> = iter::Chain<T, MIter>;
 pub fn match_types(src: Src, blobstart: usize, blobend: usize,
                    searchstr: &str, filepath: &Path,
                    search_type: SearchType,
-                   local: bool, session: &Session) -> iter::Chain<MChain<MChain<MChain<MChain<MChain<MIter>>>>>, vec::IntoIter<Match>> {
+                   local: bool, session: SessionRef) -> iter::Chain<MChain<MChain<MChain<MChain<MChain<MIter>>>>>, vec::IntoIter<Match>> {
     let it = match_extern_crate(&src, blobstart, blobend, searchstr, filepath, search_type, session).into_iter();
     let it = it.chain(match_mod(src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
     let it = it.chain(match_struct(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
@@ -219,7 +219,7 @@ pub fn first_line(blob: &str) -> String {
 
 pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
                           searchstr: &str, filepath: &Path, search_type: SearchType,
-                          session: &Session) -> Option<Match> {
+                          session: SessionRef) -> Option<Match> {
     let mut res = None;
     let blob = &msrc[blobstart..blobend];
 
@@ -476,7 +476,7 @@ thread_local!(static ALREADY_GLOBBING: Cell<Option<bool>> = Cell::new(None));
 
 pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                  searchstr: &str, filepath: &Path, search_type: SearchType,
-                 local: bool, session: &Session) -> Vec<Match> {
+                 local: bool, session: SessionRef) -> Vec<Match> {
     let mut out = Vec::new();
     let blob = &msrc[blobstart..blobend];
 

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -1,5 +1,5 @@
 use {ast, typeinf, util};
-use core::{Src, CompletionType, Session};
+use core::{Src, CompletionType, SessionRef};
 #[cfg(test)] use core;
 
 use std::iter::Iterator;
@@ -292,7 +292,7 @@ pub fn point_to_coords(src: &str, point: usize) -> (usize, usize) {
     (nlines, point - linestart)
 }
 
-pub fn point_to_coords_from_file(path: &Path, point: usize, session: &Session) -> Option<(usize, usize)> {
+pub fn point_to_coords_from_file(path: &Path, point: usize, session: SessionRef) -> Option<(usize, usize)> {
     let mut p = 0;
     for (lineno, line) in session.load_file(path).split('\n').enumerate() {
         if point < (p + line.len()) {

--- a/src/racer/snippets.rs
+++ b/src/racer/snippets.rs
@@ -1,10 +1,10 @@
 use ast::with_error_checking_parse;
-use core::{Match, MatchType, Session};
+use core::{Match, MatchType, SessionRef};
 use typeinf::get_function_declaration;
 
 use syntex_syntax::ast::ImplItemKind;
 
-pub fn snippet_for_match(m: &Match, session: &Session) -> String {
+pub fn snippet_for_match(m: &Match, session: SessionRef) -> String {
     match m.mtype {
         MatchType::Function => {
             let method = get_function_declaration(&m, session);

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -1,6 +1,6 @@
 // Type inference
 
-use core::{Match, Src, Scope, Session};
+use core::{Match, Src, Scope, SessionRef};
 use nameres::resolve_path_with_str;
 use core::Namespace::TypeNamespace;
 use core;
@@ -42,7 +42,7 @@ fn generates_skeleton_for_mod() {
     assert_eq!("mod foo {};", out);
 }
 
-fn get_type_of_self_arg(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {
+fn get_type_of_self_arg(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     debug!("get_type_of_self_arg {:?}", m);
     scopes::find_impl_start(msrc, m.point, 0).and_then(|start| {
         let decl = generate_skeleton_for_parsing(&msrc.from(start));
@@ -72,7 +72,7 @@ fn get_type_of_self_arg(m: &Match, msrc: Src, session: &Session) -> Option<core:
     })
 }
 
-fn get_type_of_fnarg(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {
+fn get_type_of_fnarg(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     if m.matchstr == "self" {
         return get_type_of_self_arg(m, msrc, session);
     }
@@ -93,7 +93,7 @@ fn get_type_of_fnarg(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty
     None
 }
 
-fn get_type_of_let_expr(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {
+fn get_type_of_let_expr(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     // ASSUMPTION: this is being called on a let decl
     let point = scopes::find_stmt_start(msrc, m.point).unwrap();
     let src = msrc.from(point);
@@ -110,7 +110,7 @@ fn get_type_of_let_expr(m: &Match, msrc: Src, session: &Session) -> Option<core:
     }
 }
 
-fn get_type_of_let_block_expr(m: &Match, msrc: Src, session: &Session, prefix: &str) -> Option<core::Ty> {
+fn get_type_of_let_block_expr(m: &Match, msrc: Src, session: SessionRef, prefix: &str) -> Option<core::Ty> {
     // ASSUMPTION: this is being called on an if let or while let decl
     let stmtstart = scopes::find_stmt_start(msrc, m.point).unwrap();
     let stmt = msrc.from(stmtstart);
@@ -129,7 +129,7 @@ fn get_type_of_let_block_expr(m: &Match, msrc: Src, session: &Session, prefix: &
     }
 }
 
-fn get_type_of_for_expr(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {
+fn get_type_of_for_expr(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     let stmtstart = scopes::find_stmt_start(msrc, m.point).unwrap();
     let stmt = msrc.from(stmtstart);
     let forpos = stmt.find("for ").unwrap();
@@ -157,7 +157,7 @@ fn get_type_of_for_expr(m: &Match, msrc: Src, session: &Session) -> Option<core:
     }
 }
 
-pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: &Session) -> Option<core::Ty> {
+pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: SessionRef) -> Option<core::Ty> {
     assert!(structmatch.mtype == core::MatchType::Struct);
 
     let src = session.load_file(&structmatch.filepath);
@@ -174,7 +174,7 @@ pub fn get_struct_field_type(fieldname: &str, structmatch: &Match, session: &Ses
     None
 }
 
-pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match, session: &Session) -> Option<core::Ty> {
+pub fn get_tuplestruct_field_type(fieldnum: u32, structmatch: &Match, session: SessionRef) -> Option<core::Ty> {
     let src = session.load_file(&structmatch.filepath);
 
     let structsrc = if let core::MatchType::EnumVariant = structmatch.mtype {
@@ -209,7 +209,7 @@ pub fn get_first_stmt(src: Src) -> Src {
     }
 }
 
-pub fn get_type_of_match(m: Match, msrc: Src, session: &Session) -> Option<core::Ty> {
+pub fn get_type_of_match(m: Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     debug!("get_type_of match {:?} ", m);
 
     match m.mtype {
@@ -231,7 +231,7 @@ macro_rules! otry {
     ($e:expr) => (match $e { Some(e) => e, None => return None })
 }
 
-pub fn get_type_from_match_arm(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {
+pub fn get_type_from_match_arm(m: &Match, msrc: Src, session: SessionRef) -> Option<core::Ty> {
     // We construct a faux match stmt and then parse it. This is because the
     // match stmt may be incomplete (half written) in the real code
 
@@ -263,14 +263,14 @@ pub fn get_type_from_match_arm(m: &Match, msrc: Src, session: &Session) -> Optio
                             }, session)
 }
 
-pub fn get_function_declaration(fnmatch: &Match, session: &Session) -> String {
+pub fn get_function_declaration(fnmatch: &Match, session: SessionRef) -> String {
     let src = session.load_file(&fnmatch.filepath);
     let start = scopes::find_stmt_start(src, fnmatch.point).unwrap();
     let end = (&src[start..]).find('{').unwrap();
     (&src[start..end+start]).to_owned()
 }
 
-pub fn get_return_type_of_function(fnmatch: &Match, session: &Session) -> Option<core::Ty> {
+pub fn get_return_type_of_function(fnmatch: &Match, session: SessionRef) -> Option<core::Ty> {
     let src = session.load_file(&fnmatch.filepath);
     let point = scopes::find_stmt_start(src, fnmatch.point).unwrap();
     (&src[point..]).find("{").and_then(|n| {

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -1,13 +1,13 @@
 // Small functions of utility
 
 use core::SearchType::{self, ExactMatch, StartsWith};
-use core::Session;
+use core::SessionRef;
 use std;
 use std::cmp;
 use std::fs::File;
 use std::path::Path;
 
-pub fn getline(filepath: &Path, linenum: usize, session: &Session) -> String {
+pub fn getline(filepath: &Path, linenum: usize, session: SessionRef) -> String {
     let src = session.load_file(filepath);
     src.src.code.lines().nth(linenum - 1).unwrap_or("not found").to_string()
 }


### PR DESCRIPTION
Replace this with a two-stage caching model: entries start
out in a temporary per-session cache with the traditional
Arena, and get transferred into a long-lived cache when
the session is finished.

This is what I promised in #452.

I'll also open an alternate PR using `Rc`.