### PR TITLE
Replace Arena/Ref caching by a simple hash map storing Rc values.

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -120,7 +120,7 @@ enum CompletePrinter {
 }
 
 #[cfg(not(test))]
-fn cache_file_contents_from_stdin<'a>(file: &PathBuf, cache: &'a core::FileCache<'a>) {
+fn cache_file_contents_from_stdin(file: &PathBuf, cache: &core::FileCache) {
     let stdin = io::stdin();
 
     let mut rawbytes = Vec::new();

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -436,7 +436,7 @@ impl<'c, 's, 'v> visit::Visitor<'v> for ExprTypeVisitor<'c, 's> {
                                  self.scope.point,
                                  self.session).and_then(|m| {
                                      let msrc = self.session.load_file_and_mask_comments(&m.filepath);
-                                     typeinf::get_type_of_match(m, msrc, self.session)
+                                     typeinf::get_type_of_match(m, msrc.as_src(), self.session)
                                  });
             }
             ast::ExprCall(ref callee_expression, _/*ref arguments*/) => {

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -9,9 +9,8 @@ use std::ops::Deref;
 use std::slice;
 use std::cmp::{min, max};
 use std::iter::{Fuse, Iterator};
+use std::rc::Rc;
 use codeiter::StmtIndicesIter;
-
-use typed_arena::Arena;
 
 use scopes;
 use nameres;
@@ -241,10 +240,14 @@ impl IndexedSource {
         }
     }
 
-    pub fn as_ref(&self) -> Src {
+    pub fn as_src(&self) -> Src {
+        self.from(0)
+    }
+
+    pub fn from(&self, from: usize) -> Src {
         Src {
             src: self,
-            from: 0,
+            from: from,
             to: self.len()
         }
     }
@@ -333,132 +336,42 @@ pub fn new_source(src: String) -> IndexedSource {
     IndexedSource::new(src)
 }
 
-pub struct FileCache<'c> {
-    /// provides allocations
-    arena: Arena<IndexedSource>,
-    /// active references to raw source
-    raw_map: RefCell<HashMap<path::PathBuf, &'c IndexedSource>>,
-    /// active references to masked source
-    masked_map: RefCell<HashMap<path::PathBuf, &'c IndexedSource>>,
-    /// allocations that should be used before allocating from the arena.
-    allocations_available: RefCell<Vec<&'c mut IndexedSource>>,
-    /// allocations that have been freed in the current generation.
-    allocations_freed: RefCell<Vec<&'c IndexedSource>>,
+pub struct FileCache {
+    /// raw source for cached files
+    raw_map: RefCell<HashMap<path::PathBuf, Rc<IndexedSource>>>,
+    /// masked source for cached files
+    masked_map: RefCell<HashMap<path::PathBuf, Rc<IndexedSource>>>,
 }
 
-impl<'c> FileCache<'c> {
-    pub fn new<'a>() -> FileCache<'a> {
+/// Caches file contents for re-use between sessions.
+///
+/// There are two versions of each file that can be cached indepdendently:
+/// "raw" and "masked", where "masked" is a version with comments and
+/// strings replaced by spaces, so that they aren't found when scanning
+/// the source for signatures.
+impl FileCache {
+    pub fn new() -> FileCache {
         FileCache {
-            arena: Arena::new(),
             raw_map: RefCell::new(HashMap::new()),
             masked_map: RefCell::new(HashMap::new()),
-            allocations_available: RefCell::new(Vec::new()),
-            allocations_freed: RefCell::new(Vec::new()),
         }
     }
 
-    /// Updates available allocations from recently freed lists
-    ///
-    /// While a session is active, allocations may be marked as freed. Reusing the allocation while
-    /// references could still be active would have unintended consequences.
-    ///
-    /// # Safety
-    ///
-    /// The FileCache must not have references handed out at the time this is called. Since the
-    /// FileCache is only accessed by the Session, it is save to call this when the Session is
-    /// dropped. Actually, it is called by the Session drop impl, and it shouldn't need to be called
-    /// at any other time.
-    pub unsafe fn update_available_allocations(&self) {
-        let mut freed = self.allocations_freed.borrow_mut();
-        let mut available = self.allocations_available.borrow_mut();
-
-        while let Some(alloc) = freed.pop() {
-            // Add a mutable reference to the available allocation list
-            let ptr = ::std::mem::transmute::<*const IndexedSource, *mut IndexedSource>(alloc);
-            available.push(&mut *ptr);
-        }
+    /// Add/Replace a file in both versions.
+    pub fn cache_file_contents<T>(&self, filepath: &path::Path, buf: T)
+        where T: Into<String>
+    {
+        let src = IndexedSource::new(buf.into());
+        let masked_src = IndexedSource::new(scopes::mask_comments(src.as_src()));
+        self.raw_map.borrow_mut().insert(filepath.to_path_buf(), Rc::new(src));
+        self.masked_map.borrow_mut().insert(filepath.to_path_buf(), Rc::new(masked_src));
     }
 
-    /// Checks if allocations are available
-    #[inline]
-    fn needs_alloc(&self) -> bool {
-        self.allocations_available.borrow().len() == 0
-    }
-
-    /// Allocate an IndexedSource using provided value.
-    ///
-    /// Attempts to reuse a freed allocation before allocating from arena.
-    ///
-    /// If the contract about freed allocations is not upheld, this could result in undefined
-    /// behavior.
-    ///
-    /// TODO should this be marked unsafe until it can be refactored into a safer api?
-    fn alloc(&self, value: IndexedSource) -> &mut IndexedSource {
-        if self.needs_alloc() {
-            // new alloc
-            self.arena.alloc(value)
-        } else {
-            // reuse freed alloc
-            unsafe {
-                // Get a mutable reference to the old object
-                let ptr: *mut IndexedSource = self.allocations_available.borrow_mut().pop().unwrap();
-
-                // Run drop for the previously stored value. This has to be done when the allocation
-                // is being reused so that the memory is always intialized to valid values.
-                ::std::mem::drop(::std::ptr::read(ptr));
-
-                // copy provided value into ptr without running drop
-                ::std::ptr::write(ptr, value);
-
-                // A reference to the updated allocation is returned.
-                &mut *ptr
-            }
-        }
-    }
-
-
-    /// Cache the contents of `buf` using the given `Path` for a key.
-    ///
-    /// Subsequent calls to load_file will return an IndexedSource of the provided buf.
-    pub fn cache_file_contents<T>(&'c self, filepath: &path::Path, buf: T)
-    where T: Into<String> {
-        // update raw file
-        {
-            let mut cache = self.raw_map.borrow_mut();
-
-            // Mark previous allocation free
-            if let Some(prev) = cache.get(filepath) {
-                self.allocations_freed.borrow_mut().push(prev);
-            }
-
-            cache.insert(filepath.to_path_buf(), {
-                self.alloc(IndexedSource::new(buf.into()))
-            });
-        }
-
-        // also need to update masked version
-        {
-            // TODO stash old version in free list
-            let mut cache = self.masked_map.borrow_mut();
-
-            if let Some(prev) = cache.get(filepath) {
-                self.allocations_freed.borrow_mut().push(prev);
-            }
-
-            cache.insert(filepath.to_path_buf(), {
-                let src = self.load_file(filepath);
-
-                // create a new IndexedSource with new source, but same indices
-                self.alloc(src.src.with_src(scopes::mask_comments(src)))
-            });
-        }
-    }
-
-    pub fn open_file(&self, path: &path::Path) -> io::Result<File> {
+    fn open_file(&self, path: &path::Path) -> io::Result<File> {
         File::open(path)
     }
 
-    pub fn read_file(&self, path: &path::Path) -> Vec<u8> {
+    fn read_file(&self, path: &path::Path) -> Vec<u8> {
         let mut rawbytes = Vec::new();
         if let Ok(mut f) = self.open_file(path) {
             f.read_to_end(&mut rawbytes).unwrap();
@@ -476,37 +389,37 @@ impl<'c> FileCache<'c> {
         }
     }
 
-    pub fn load_file(&'c self, filepath: &path::Path) -> Src<'c> {
-        let mut cache = self.raw_map.borrow_mut();
-        cache.entry(filepath.to_path_buf()).or_insert_with(|| {
-            let rawbytes = self.read_file(filepath);
-            let res = String::from_utf8(rawbytes).unwrap();
-            self.alloc(IndexedSource::new(res))
-        }).as_ref()
+    pub fn load_file(&self, filepath: &path::Path) -> Rc<IndexedSource> {
+        if let Some(src) = self.raw_map.borrow().get(filepath) {
+            return src.clone();
+        }
+        // nothing found, insert into cache
+        let rawbytes = self.read_file(filepath);
+        let res = String::from_utf8(rawbytes).unwrap();
+        let src = Rc::new(IndexedSource::new(res));
+        self.raw_map.borrow_mut().insert(filepath.to_path_buf(), src.clone());
+        src
     }
 
-    pub fn load_file_and_mask_comments(&'c self, filepath: &path::Path) -> Src<'c> {
-        let mut cache = self.masked_map.borrow_mut();
-        cache.entry(filepath.to_path_buf()).or_insert_with(|| {
-            let src = self.load_file(filepath);
-            // create a new IndexedSource with new source, but same indices
-            self.alloc(src.src.with_src(scopes::mask_comments(src)))
-        }).as_ref()
+    pub fn load_file_and_mask_comments(&self, filepath: &path::Path) -> Rc<IndexedSource> {
+        if let Some(src) = self.masked_map.borrow().get(filepath) {
+            return src.clone();
+        }
+        // nothing found, insert into cache
+        let src = self.load_file(filepath);
+        let msrc = Rc::new(src.with_src(scopes::mask_comments(src.as_src())));
+        self.masked_map.borrow_mut().insert(filepath.to_path_buf(),
+                                            msrc.clone());
+        msrc
     }
 }
 
 pub struct Session<'c> {
     query_path: path::PathBuf,            // the input path of the query
     substitute_file: path::PathBuf,       // the temporary file
-    cache: &'c FileCache<'c>              // cache for file contents
+    cache: &'c FileCache,                 // cache for file contents
 }
 
-
-impl<'a> Drop for Session<'a> {
-    fn drop(&mut self) {
-        unsafe { self.cache.update_available_allocations(); }
-    }
-}
 
 impl<'c> fmt::Debug for Session<'c> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -515,7 +428,7 @@ impl<'c> fmt::Debug for Session<'c> {
 }
 
 impl<'c> Session<'c> {
-    pub fn from_path(cache: &'c FileCache<'c>,
+    pub fn from_path(cache: &'c FileCache,
                      query_path: &path::Path,
                      substitute_file: &path::Path) -> Session<'c> {
         Session {
@@ -537,23 +450,16 @@ impl<'c> Session<'c> {
     }
 
     pub fn cache_file_contents<T>(&self, filepath: &path::Path, buf: T)
-    where T: Into<String> {
+        where T: Into<String>
+    {
         self.cache.cache_file_contents(filepath, buf);
     }
 
-    pub fn open_file(&self, path: &path::Path) -> io::Result<File> {
-        self.cache.open_file(self.resolve_path(path))
-    }
-
-    pub fn read_file(&self, path: &path::Path) -> Vec<u8> {
-        self.cache.read_file(self.resolve_path(path))
-    }
-
-    pub fn load_file(&self, filepath: &path::Path) -> Src<'c> {
+    pub fn load_file(&self, filepath: &path::Path) -> Rc<IndexedSource> {
         self.cache.load_file(self.resolve_path(filepath))
     }
 
-    pub fn load_file_and_mask_comments(&self, filepath: &path::Path) -> Src<'c> {
+    pub fn load_file_and_mask_comments(&self, filepath: &path::Path) -> Rc<IndexedSource> {
         self.cache.load_file_and_mask_comments(self.resolve_path(filepath))
     }
 }

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -18,7 +18,7 @@ pub const PATH_SEP: &'static str = ";";
 fn search_struct_fields(searchstr: &str, structmatch: &Match,
                         search_type: SearchType, session: &Session) -> vec::IntoIter<Match> {
     let src = session.load_file(&structmatch.filepath);
-    let opoint = scopes::find_stmt_start(src, structmatch.point);
+    let opoint = scopes::find_stmt_start(src.as_src(), structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint.unwrap()..]);
 
     let fields = ast::parse_struct_fields(structsrc.to_owned(),
@@ -65,7 +65,7 @@ pub fn search_for_impl_methods(match_request: &Match,
         // find the opening brace and skip to it.
         (&src[m.point..]).find("{").map(|n| {
             let point = m.point + n + 1;
-            for m in search_scope_for_methods(point, src, fieldsearchstr, &m.filepath, search_type) {
+            for m in search_scope_for_methods(point, src.as_src(), fieldsearchstr, &m.filepath, search_type) {
                 out.push(m);
             }
         });
@@ -484,7 +484,7 @@ pub fn search_next_scope(mut startpoint: usize, pathseg: &core::PathSegment,
             startpoint += n + 1;
         });
     }
-    search_scope(startpoint, startpoint, filesrc, pathseg, filepath, search_type, local, namespace, session)
+    search_scope(startpoint, startpoint, filesrc.as_src(), pathseg, filepath, search_type, local, namespace, session)
 }
 
 pub fn get_crate_file(name: &str, from_path: &Path) -> Option<PathBuf> {
@@ -774,7 +774,7 @@ pub fn search_prelude_file(pathseg: &core::PathSegment, search_type: SearchType,
         if path_exists(&filepath) {
             let msrc = session.load_file_and_mask_comments(&filepath);
             let is_local = true;
-            for m in search_scope(0, 0, msrc, pathseg, &filepath, search_type, is_local, namespace, session) {
+            for m in search_scope(0, 0, msrc.as_src(), pathseg, &filepath, search_type, is_local, namespace, session) {
                 out.push(m);
             }
         }
@@ -872,7 +872,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
         }
     }
 
-    for m in search_local_scopes(pathseg, filepath, msrc, pos, search_type, namespace, session) {
+    for m in search_local_scopes(pathseg, filepath, msrc.as_src(), pos, search_type, namespace, session) {
         out.push(m);
         if let ExactMatch = search_type {
             if !out.is_empty() {
@@ -910,7 +910,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
 // Get the scope corresponding to super::
 pub fn get_super_scope(filepath: &Path, pos: usize, session: &Session) -> Option<core::Scope> {
     let msrc = session.load_file_and_mask_comments(filepath);
-    let mut path = scopes::get_local_module_path(msrc, pos);
+    let mut path = scopes::get_local_module_path(msrc.as_src(), pos);
     debug!("get_super_scope: path: {:?} filepath: {:?} {} {:?}", path, filepath, pos, session);
     if path.is_empty() {
         let moduledir;
@@ -993,7 +993,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                     debug!("searching an enum '{}' (whole path: {:?}) searchtype: {:?}", m.matchstr, path, search_type);
 
                     let filesrc = session.load_file(&m.filepath);
-                    let scopestart = scopes::find_stmt_start(filesrc, m.point).unwrap();
+                    let scopestart = scopes::find_stmt_start(filesrc.as_src(), m.point).unwrap();
                     let scopesrc = filesrc.from(scopestart);
                     scopesrc.iter_stmts().nth(0).map(|(blobstart,blobend)| {
                         for m in matchers::match_enum_variants(&filesrc,
@@ -1014,7 +1014,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                         // find the opening brace and skip to it.
                         (&src[m.point..]).find("{").map(|n| {
                             let point = m.point + n + 1;
-                            for m in search_scope(point, point, src, pathseg, &m.filepath, search_type, m.local, namespace, session) {
+                            for m in search_scope(point, point, src.as_src(), pathseg, &m.filepath, search_type, m.local, namespace, session) {
                                 out.push(m);
                             }
                         });
@@ -1141,7 +1141,7 @@ pub fn search_for_field_or_method(context: Match, searchstr: &str, search_type: 
             let src = session.load_file(&m.filepath);
             (&src[m.point..]).find("{").map(|n| {
                 let point = m.point + n + 1;
-                for m in search_scope_for_methods(point, src, searchstr, &m.filepath, search_type) {
+                for m in search_scope_for_methods(point, src.as_src(), searchstr, &m.filepath, search_type) {
                     out.push(m);
                 }
             });

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -87,12 +87,12 @@ fn finds_subnested_module() {
     }";
     let point = coords_to_point(&src, 4, 12);
     let src = core::new_source(String::from(src));
-    let v = get_local_module_path(src.as_ref(), point);
+    let v = get_local_module_path(src.as_src(), point);
     assert_eq!("foo", &v[0][..]);
     assert_eq!("bar", &v[1][..]);
 
     let point = coords_to_point(&src, 3, 8);
-    let v = get_local_module_path(src.as_ref(), point);
+    let v = get_local_module_path(src.as_src(), point);
     assert_eq!("foo", &v[0][..]);
 }
 
@@ -324,7 +324,7 @@ fn myfn() {
 ");
     let src = core::new_source(src);
     let point = coords_to_point(&src, 4, 10);
-    let start = scope_start(src.as_ref(), point);
+    let start = scope_start(src.as_src(), point);
     assert!(start == 12);
 }
 
@@ -341,7 +341,7 @@ fn myfn() {
 ");
     let src = core::new_source(src);
     let point = coords_to_point(&src, 7, 10);
-    let start = scope_start(src.as_ref(), point);
+    let start = scope_start(src.as_src(), point);
     assert!(start == 12);
 }
 
@@ -353,7 +353,7 @@ this is a line // with a comment
 some more
 ");
     let src = core::new_source(src);
-    let r = mask_comments(src.as_ref());
+    let r = mask_comments(src.as_src());
 
     assert!(src.len() == r.len());
     // characters at the start are the same

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 pub fn getline(filepath: &Path, linenum: usize, session: &Session) -> String {
     let src = session.load_file(filepath);
-    src.src.code.lines().nth(linenum - 1).unwrap_or("not found").to_string()
+    src.code.lines().nth(linenum - 1).unwrap_or("not found").to_string()
 }
 
 pub fn is_pattern_char(c: char) -> bool {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -195,8 +195,8 @@ fn completes_pub_fn_locally_precached() {
     let path = f.path();
     let pos = scopes::coords_to_point(src, 6, 18);
     let cache = core::FileCache::new();
+    cache.cache_file_contents(&path, src);
     let session = core::Session::from_path(&cache, &path, &path);
-    session.cache_file_contents(&path, src);
     let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     assert_eq!("apple".to_string(), got.matchstr.to_string());
 }
@@ -236,10 +236,10 @@ fn overwriting_cached_files() {
     // the newly cached contents.
     macro_rules! cache_and_assert {
         ($src:ident) => {{
+            cache.cache_file_contents(&path, $src);
             let session = core::Session::from_path(&cache, &path, &path);
-            session.cache_file_contents(&path, $src);
-            assert_eq!($src, &session.load_file(&path).src.code[..]);
-            assert_eq!($src, &session.load_file_and_mask_comments(&path).src.code[..]);
+            assert_eq!($src, &session.load_file(&path).code[..]);
+            assert_eq!($src, &session.load_file_and_mask_comments(&path).code[..]);
         }}
     }
 


### PR DESCRIPTION
This is an alternate for #497.

The cache handling is much simpler, with the downside that it can't hand out references, it hands out `Rc` clones. That means that the callers have to convert them to `Src` all over the place, which is the reason for the added `as_src()`.  (This used to be `as_ref()` but that is already a `Rc` method.)

I can't see a difference in speed; the additional refcount operations are likely completely insignificant.

A caveat is that this cache is not threadsafe, which might matter if a daemon process should handle concurrent requests (not sure that makes sense though). Switching to `Arc` and `Mutex` might be enough to make it `Sync`.

/cc @jwilm