### PR TITLE
Extern crate match fix

### DIFF
--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -223,7 +223,7 @@ pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
     let mut res = None;
     let blob = &msrc[blobstart..blobend];
 
-    if txt_matches(search_type, &format!("extern crate {};", searchstr), blob) &&
+    if txt_matches(search_type, &format!("extern crate {}", searchstr), blob) &&
         !(txt_matches(search_type, &format!("extern crate {} as", searchstr), blob))
         || (blob.starts_with("extern crate") &&
             txt_matches(search_type, &format!("as {}", searchstr), blob)) {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -594,6 +594,20 @@ fn finds_macro() {
 }
 
 #[test]
+fn finds_extern_crate() {
+	let src = "
+    extern crate fixtures;
+    fixtures
+    ";
+	let f = TmpFile::new(src);
+	let path = f.path();
+	let pos = scopes::coords_to_point(src, 3, 5);
+	let cache = core::FileCache::new();
+	let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
+	assert_eq!(got.matchstr, "fixtures".to_string());
+}
+
+#[test]
 fn finds_fn_arg() {
     let src="
     fn myfn(myarg: &str) {


### PR DESCRIPTION
Racer was not picking up the names of actual crates from `extern crate {}` lines.

So for example this code would not match the `ecs` crate:
***************************
`extern crate ecs`
`ec` _(run racer here)_
***************************
This was due to the external crate matching code placing an unneeded `;` at the end of the searchstr it was trying to match.

`if txt_matches(search_type, &format!("extern crate {};", searchstr), blob)`

So it would try to find "extern crate ec;" inside of "extern crate ecs;" and not find anything.