### PR TITLE
Multiple use glob fix

### DIFF
--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -509,6 +509,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                 debug!("found a glob: now searching for {:?}", path);
                 let iter_path = resolve_path(&path, filepath, blobstart, search_type, BothNamespaces, session);
                 if let StartsWith = search_type {
+                	ALREADY_GLOBBING.with(|c| { c.set(None) });
                     return iter_path.collect();
                 }
                 for m in iter_path {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -405,6 +405,36 @@ fn follows_use_glob() {
 }
 
 #[test]
+fn follows_multiple_use_globs() {
+	let src1="
+    pub fn src1fn() {}
+    ";
+	let src2="
+    pub fn src2fn() {}
+    ";
+    let src ="
+    use multiple_glob_test1::*;
+    use multiple_glob_test2::*;
+    mod multiple_glob_test1;
+    mod multiple_glob_test2;
+    
+    src
+    ";
+    
+    let _tmpsrc1 = TmpFile::with_name("multiple_glob_test1.rs", src1);
+    let _tmpsrc2 = TmpFile::with_name("multiple_glob_test2.rs", src2);
+    let tmpsrc = TmpFile::new(src);
+    let path = tmpsrc.path();
+    let pos = scopes::coords_to_point(src, 7, 7);
+    let cache = core::FileCache::new();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path));
+    let completion_strings = got.into_iter().map(|raw_match| raw_match.matchstr).collect::<Vec<_>>();
+    
+    assert!(completion_strings.contains(&"src1fn".to_string()) && completion_strings.contains(&"src2fn".to_string()),
+    format!("Results should contain BOTH \"src1fn\" and \"src2fn\". Actual returned results: {:?} ", completion_strings));
+}
+
+#[test]
 fn follows_use_local_package() {
     let src="
     extern crate fixtures;


### PR DESCRIPTION
If a file contained multiple use globs in the available scope, then only the use glob processed first would be evaluated.

e.g.
****************
extern crate A;
extern crate B;

use A::*;
use B::*;

text <-- (Run Racer Here)
****************

- Running Racer here would only give matches for crate A.
- This was due to match_use not setting "ALREADY_GLOBBING" back to "None" once it finished working on the glob before exiting on the early return statement, which would prevent any other use globs from being processed afterwards.