### PR TITLE
Add note for rustup/multirust-rs users

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ As mentioned in the command output, don't forget to add the installation directo
 
    ```./target/release/racer complete std::io::B ```  (should show some completions)
 
+### Note for [rustup/multirust-rs](https://github.com/rust-lang-nursery/multirust-rs) users
+
+*This does not apply to [multirust](https://github.com/brson/multirust)!*
+
+To enable completion for cargo crates, you need to set the `CARGO_HOME` environment variable to `.cargo` in your home directory.
+
 ## Editors/IDEs Supported
 
 ### Eclipse integration


### PR DESCRIPTION
Also see https://github.com/rust-lang-nursery/multirust-rs/issues/46

The problem is that both [rustup/multirust-rs](https://github.com/rust-lang-nursery/multirust-rs) and [multirust](https://github.com/brson/multirust) use the .multirust directory but only multirust has separate cargo homes for different toolchains.

After https://github.com/rust-lang-nursery/multirust-rs/issues/247 is resolved, racer can (more easily) differentiate between the two cases.