### PR TITLE
Fix cargo lock lookup

### DIFF
--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -259,7 +259,7 @@ fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> 
                 if let Some(path) = reader
                     .map(|entry| entry.unwrap().path())
                     .find(|path| path.to_str().unwrap().starts_with(start_name)) {
-                        d = path.clone();                        
+                        d = path.clone();
                     } else {
                         continue;
                     }
@@ -269,7 +269,7 @@ fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> 
         } else {
             d.push(kratename.to_owned() + "-" + &version);
         }
-        
+
         d.push("src");
         debug!("crate path {:?}",d);
 

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -68,10 +68,15 @@ fn empty_if_no_branch() {
 }
 
 fn find_src_via_lockfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
+    trace!("find_src_via_lockfile searching for {} in {:?}", kratename, cargofile);
     if let Some(packages) = get_cargo_packages(cargofile) {
+        trace!("find_src_via_lockfile got packages");
         for package in packages {
+            trace!("find_src_via_lockfile examining {:?}", package);
             if let Some(package_source) = package.source.clone() {
+                trace!("find_src_via_lockfile package_source {:?}", package_source);
                 if let Some(tomlfile) = find_cargo_tomlfile(package_source.as_path()) {
+                    trace!("find_src_via_lockfile tomlfile {:?}", tomlfile);
                     let package_name = get_package_name(tomlfile.as_path());
 
                     debug!("find_src_via_lockfile package_name: {}", package_name);
@@ -83,6 +88,8 @@ fn find_src_via_lockfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
             }
         }
     }
+
+    trace!("find_src_via_lockfile returning None");
     None
 }
 
@@ -232,6 +239,7 @@ fn get_cargo_rootdir(cargofile: &Path) -> Option<PathBuf> {
 }
 
 fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> Option<PathBuf> {
+    trace!("get_versioned_cratefile searching for {}", kratename);
     let mut d = otry!(get_cargo_rootdir(cargofile));
 
     debug!("get_versioned_cratefile: cargo rootdir is {:?}",d);
@@ -277,6 +285,7 @@ fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> 
         debug!("crate path with lib.rs {:?}",d);
 
         if let Err(_) = File::open(&d) {
+            trace!("failed to open crate path {:?}", d);
             // It doesn't exist, so try /lib.rs
             d.pop();
             d.pop();
@@ -284,6 +293,7 @@ fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> 
         }
 
         if let Err(_) = File::open(&d) {
+            trace!("failed to open crate path {:?}", d);
             continue;
         }
 
@@ -293,6 +303,7 @@ fn get_versioned_cratefile(kratename: &str, version: &str, cargofile: &Path) -> 
  }
 
 fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
+    trace!("find_src_via_tomlfile looking for {}", kratename);
     // only look for 'path' references here.
     // We find the git and crates.io stuff via the lockfile
     let table = parse_toml_file(cargofile).unwrap();
@@ -493,6 +504,8 @@ pub fn get_crate_file(kratename: &str, from_path: &Path) -> Option<PathBuf> {
             if let Some(f) = find_src_via_lockfile(kratename, &lockfile) {
                 return Some(f);
             }
+        } else {
+            trace!("did not find lock file at {:?}", lockfile);
         }
 
         // oh, no luck with the lockfile. Try the tomlfile

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -114,19 +114,22 @@ fn get_cargo_packages(cargofile: &Path) -> Option<Vec<PackageInfo>> {
 
     let mut result = Vec::new();
 
-    macro_rules! unwrap_or_continue {
-        ($opt:expr) => {
-            match $opt {
-                Some(v) => v,
-                _ => continue,
-            }
-        }
-    }
-
     for package_element in packages_array {
         if let &toml::Value::Table(ref package_table) = package_element {
             if let Some(&toml::Value::String(ref package_name)) = package_table.get("name") {
                 trace!("get_cargo_packages processing {}", package_name);
+
+                macro_rules! unwrap_or_continue {
+                    ($opt:expr) => {
+                        match $opt {
+                            Some(v) => v,
+                            _ => {
+                                debug!("get_cargo_packages skipping {}", package_name);
+                                continue;
+                            }
+                        }
+                    }
+                }
 
                 let package_version = unwrap_or_continue!(getstr(package_table, "version"));
                 let package_source = unwrap_or_continue!(getstr(package_table, "source"));

--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -307,6 +307,7 @@ fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
     // only look for 'path' references here.
     // We find the git and crates.io stuff via the lockfile
     let table = parse_toml_file(cargofile).unwrap();
+    let parent = otry!(cargofile.parent());
 
     // is it this lib?  (e.g. you're searching from tests to find the main library crate)
     {
@@ -322,14 +323,14 @@ fn find_src_via_tomlfile(kratename: &str, cargofile: &Path) -> Option<PathBuf> {
         };
 
         let mut lib_name = package_name;
-        let mut lib_path = otry!(cargofile.parent()).join("src").join("lib.rs");
+        let mut lib_path = parent.join("src").join("lib.rs");
         if let Some(&toml::Value::Table(ref t)) = table.get("lib") {
             if let Some(&toml::Value::String(ref name)) = t.get("name") {
                 lib_name = name;
             }
             if let Some(&toml::Value::String(ref pathstr)) = t.get("path") {
                 let p = Path::new(pathstr);
-                lib_path = otry!(cargofile.parent()).join(p);
+                lib_path = parent.join(p);
             }
         }
 


### PR DESCRIPTION
The main loop of `racer::cargo::get_cargo_packages` previously used `otry!` extensively which would cause the entire function to return None in the case that any of the crates in the package list didn't have all of the desired properties. `otry!` usage in this function was replaced with an `unwrap_or_continue!` macro which yields the value of some or `continue`s which skips the current package.

The remaining changes are cleanup and logging additions. The main commit to look at for review purposes is 27602934fe6d52525016c18e5b1abfa07fb2aec3. There was also some minor refactoring in 6eaefb2ad83b47312e4c089963ef5c7d6a55536d.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phildawes/racer/531)
<!-- Reviewable:end -->
