### PR TITLE
Add function and struct docs to `Match` type

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -90,7 +90,6 @@ fn match_fn(m: Match, session: &core::Session, interface: Interface) {
 
 #[cfg(not(test))]
 fn complete(cfg: Config, print_type: CompletePrinter) {
-    println!("{:?} {:?}", cfg, print_type);
     if cfg.fqn.is_some() {
         return external_complete(cfg, print_type);
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -38,23 +38,25 @@ fn match_with_snippet_fn(m: Match, session: &core::Session, interface: Interface
     let snippet = racer::snippets::snippet_for_match(&m, session);
     match interface {
         Interface::Text =>
-            println!("MATCH {};{};{};{};{};{:?};{}",
+            println!("MATCH {};{};{};{};{};{:?};{};{:?}",
                         m.matchstr,
                         snippet,
                         linenum.to_string(),
                         charnum.to_string(),
                         m.filepath.to_str().unwrap(),
                         m.mtype,
-                        m.contextstr),
+                        m.contextstr,
+                        m.docs),
         Interface::TabText =>
-            println!("MATCH\t{}\t{}\t{}\t{}\t{}\t{:?}\t{}",
+            println!("MATCH\t{}\t{}\t{}\t{}\t{}\t{:?}\t{}\t{:?}",
                         m.matchstr,
                         snippet,
                         linenum.to_string(),
                         charnum.to_string(),
                         m.filepath.to_str().unwrap(),
                         m.mtype,
-                        m.contextstr),
+                        m.contextstr,
+                        m.docs),
     }
 }
 

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -71,6 +71,7 @@ pub struct Match {
     pub contextstr: String,
     pub generic_args: Vec<String>,
     pub generic_types: Vec<PathSearch>,  // generic types are evaluated lazily
+    pub docs: String,
 }
 
 
@@ -85,6 +86,7 @@ impl Match {
             contextstr: self.contextstr.clone(),
             generic_args: self.generic_args.clone(),
             generic_types: generic_types,
+            docs: self.docs.clone(),
         }
     }
 }

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -117,7 +117,7 @@ fn match_pattern_start(src: &str, blobstart: usize, blobend: usize,
                 contextstr: first_line(blob),
                 generic_args: Vec::new(),
                 generic_types: Vec::new(),
-                docs: String::from(""),  //TODO: fix
+                docs: String::new(),
             })
         }
     }
@@ -160,7 +160,7 @@ fn match_pattern_let(msrc: &str, blobstart: usize, blobend: usize,
                                    contextstr: first_line(blob),
                                    generic_args: Vec::new(),
                                    generic_types: Vec::new(),
-                                   docs: String::from(""),  //TODO: fix
+                                   docs: String::new(),
                          });
                 if let ExactMatch = search_type {
                     break;
@@ -210,7 +210,7 @@ pub fn match_for(msrc: &str, blobstart: usize, blobend: usize,
                              contextstr: first_line(blob),
                              generic_args: Vec::new(),
                              generic_types: Vec::new(),
-                             docs: String::from(""),  //TODO: fix
+                             docs: String::new(),
             });
         }
     }
@@ -267,7 +267,7 @@ pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
                                   contextstr: cratepath.to_str().unwrap().to_owned(),
                                   generic_args: Vec::new(),
                                   generic_types: Vec::new(),
-                                  docs: String::from(""),  //TODO: fix
+                                  docs: String::new(),
                 });
             });
         }
@@ -298,7 +298,7 @@ pub fn match_mod(msrc: Src, blobstart: usize, blobend: usize,
                 contextstr: filepath.to_str().unwrap().to_owned(),
                 generic_args: Vec::new(),
                 generic_types: Vec::new(),
-                docs: String::from(""),  //TODO: fix
+                docs: String::new(),  //TODO: fix
             })
         } else {
             // get internal module nesting
@@ -320,7 +320,7 @@ pub fn match_mod(msrc: Src, blobstart: usize, blobend: usize,
                     contextstr: modpath.to_str().unwrap().to_owned(),
                     generic_args: Vec::new(),
                     generic_types: Vec::new(),
-                    docs: String::from(""),  //TODO: fix
+                    docs: String::new(),  //TODO: fix
                 })
             }
         }
@@ -360,7 +360,7 @@ pub fn match_struct(msrc: &str, blobstart: usize, blobend: usize,
             contextstr: first_line(blob),
             generic_args: generics.generic_args,
             generic_types: Vec::new(),
-            docs: String::from(""),  //TODO: fix
+            docs: find_doc(msrc, blobstart),
         })
     } else {
         None
@@ -386,7 +386,7 @@ pub fn match_type(msrc: &str, blobstart: usize, blobend: usize,
             contextstr: first_line(blob),
             generic_args: Vec::new(),
             generic_types: Vec::new(),
-            docs: String::from(""),  //TODO: fix
+            docs: find_doc(msrc, blobstart),
         })
     } else {
         None
@@ -637,7 +637,7 @@ pub fn match_macro(msrc: &str, blobstart: usize, blobend: usize,
             contextstr: first_line(blob),
             generic_args: Vec::new(),
             generic_types: Vec::new(),
-            docs: String::from(""),  //TODO: fix
+            docs: String::new(),
         })
     } else {
         None

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -41,7 +41,7 @@ fn search_struct_fields(searchstr: &str, structmatch: &Match,
                                 contextstr: contextstr,
                                 generic_args: Vec::new(),
                                 generic_types: Vec::new(),
-                                docs: String::from(""),  //TODO: fix
+                                docs: String::new(),
 
             });
         }
@@ -109,7 +109,7 @@ fn search_scope_for_methods(point: usize, src: Src, searchstr: &str, filepath: &
                            contextstr: signature.to_owned(),
                            generic_args: Vec::new(),
                            generic_types: Vec::new(),
-                           docs: String::from(""),  //TODO: fix
+                           docs: String::new(),
 
                 };
                 out.push(m);
@@ -153,7 +153,7 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
                                     contextstr: "".into(),
                                     generic_args: Vec::new(),
                                     generic_types: Vec::new(),
-                                    docs: String::from(""),  //TODO: fix
+                                    docs: String::new(),
                                 };
                                 out.push(m);
                             }
@@ -290,7 +290,7 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &
                                     contextstr: lhs.trim().to_owned(),
                                     generic_args: Vec::new(),
                                     generic_types: Vec::new(),
-                                    docs: String::from(""),  //TODO: fix
+                                    docs: String::new(),
                     });
                     if let SearchType::ExactMatch = search_type {
                         break;
@@ -347,7 +347,7 @@ fn search_fn_args(fnstart: usize, open_brace_pos: usize, msrc: &str,
                                 contextstr: s.to_owned(),
                                 generic_args: Vec::new(),
                                 generic_types: Vec::new(),
-                                docs: String::from(""),  //TODO: fix
+                                docs: String::new(),
                 };
                 debug!("search_fn_args matched: {:?}", m);
                 out.push(m);
@@ -386,7 +386,7 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
                                        contextstr: (&fname[3..]).to_owned(),
                                        generic_args: Vec::new(),
                                        generic_types: Vec::new(),
-                                       docs: String::from(""),  //TODO: fix
+                                       docs: String::new(),
                         };
                         out.push(m);
                     }
@@ -406,7 +406,7 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
                                            contextstr: filepath.to_str().unwrap().to_owned(),
                                            generic_args: Vec::new(),
                                            generic_types: Vec::new(),
-                                           docs: String::from(""),  //TODO: fix
+                                           docs: String::new(),
                             };
                             out.push(m);
                         }
@@ -422,7 +422,7 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
                                        contextstr: fpath_buf.to_str().unwrap().to_owned(),
                                        generic_args: Vec::new(),
                                        generic_types: Vec::new(),
-                                       docs: String::from(""),  //TODO: fix
+                                       docs: String::new(),
 
                         };
                         out.push(m);
@@ -651,7 +651,7 @@ pub fn search_scope(start: usize, point: usize, src: Src,
                                   contextstr: cratepath.to_str().unwrap().to_owned(),
                                   generic_args: Vec::new(),
                                   generic_types: Vec::new(),
-                                  docs: String::from(""),  //TODO: fix
+                                  docs: String::new(),
 
                 });
             });
@@ -825,7 +825,7 @@ pub fn resolve_path_with_str(path: &core::Path, filepath: &Path, pos: usize,
                 contextstr: "str".into(),
                 generic_args: vec![],
                 generic_types: vec![],
-                docs: String::from(""),  //TODO: fix
+                docs: String::new(),
 
             });
         }
@@ -885,7 +885,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
                         contextstr: cratepath.to_str().unwrap().to_owned(),
                         generic_args: Vec::new(),
                         generic_types: Vec::new(),
-                        docs: String::from(""),  //TODO: fix
+                        docs: String::new(),
 
             });
         });
@@ -1081,7 +1081,7 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
                            contextstr: path.to_str().unwrap().to_owned(),
                            generic_args: Vec::new(),
                            generic_types: Vec::new(),
-                           docs: String::from(""),  //TODO: fix
+                           docs: String::new(),
 
                        });
         });

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -39,7 +39,10 @@ fn search_struct_fields(searchstr: &str, structmatch: &Match,
                                 local: structmatch.local,
                                 mtype: StructField,
                                 contextstr: contextstr,
-                                generic_args: Vec::new(), generic_types: Vec::new()
+                                generic_args: Vec::new(),
+                                generic_types: Vec::new(),
+                                docs: String::from(""),  //TODO: fix
+
             });
         }
     }
@@ -104,7 +107,10 @@ fn search_scope_for_methods(point: usize, src: Src, searchstr: &str, filepath: &
                            local: true,
                            mtype: Function,
                            contextstr: signature.to_owned(),
-                           generic_args: Vec::new(), generic_types: Vec::new()
+                           generic_args: Vec::new(),
+                           generic_types: Vec::new(),
+                           docs: String::from(""),  //TODO: fix
+
                 };
                 out.push(m);
             }
@@ -146,7 +152,8 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
                                     mtype: Impl,
                                     contextstr: "".into(),
                                     generic_args: Vec::new(),
-                                    generic_types: Vec::new()
+                                    generic_types: Vec::new(),
+                                    docs: String::from(""),  //TODO: fix
                                 };
                                 out.push(m);
                             }
@@ -282,7 +289,8 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &
                                     mtype: MatchArm,
                                     contextstr: lhs.trim().to_owned(),
                                     generic_args: Vec::new(),
-                                    generic_types: Vec::new()
+                                    generic_types: Vec::new(),
+                                    docs: String::from(""),  //TODO: fix
                     });
                     if let SearchType::ExactMatch = search_type {
                         break;
@@ -338,7 +346,8 @@ fn search_fn_args(fnstart: usize, open_brace_pos: usize, msrc: &str,
                                 mtype: FnArg,
                                 contextstr: s.to_owned(),
                                 generic_args: Vec::new(),
-                                generic_types: Vec::new()
+                                generic_types: Vec::new(),
+                                docs: String::from(""),  //TODO: fix
                 };
                 debug!("search_fn_args matched: {:?}", m);
                 out.push(m);
@@ -376,7 +385,8 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
                                        mtype: Module,
                                        contextstr: (&fname[3..]).to_owned(),
                                        generic_args: Vec::new(),
-                                       generic_types: Vec::new()
+                                       generic_types: Vec::new(),
+                                       docs: String::from(""),  //TODO: fix
                         };
                         out.push(m);
                     }
@@ -395,7 +405,8 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
                                            mtype: Module,
                                            contextstr: filepath.to_str().unwrap().to_owned(),
                                            generic_args: Vec::new(),
-                                           generic_types: Vec::new()
+                                           generic_types: Vec::new(),
+                                           docs: String::from(""),  //TODO: fix
                             };
                             out.push(m);
                         }
@@ -410,7 +421,9 @@ pub fn do_file_search(searchstr: &str, currentdir: &Path) -> vec::IntoIter<Match
                                        mtype: Module,
                                        contextstr: fpath_buf.to_str().unwrap().to_owned(),
                                        generic_args: Vec::new(),
-                                       generic_types: Vec::new()
+                                       generic_types: Vec::new(),
+                                       docs: String::from(""),  //TODO: fix
+
                         };
                         out.push(m);
                     }
@@ -637,7 +650,9 @@ pub fn search_scope(start: usize, point: usize, src: Src,
                                   mtype: Module,
                                   contextstr: cratepath.to_str().unwrap().to_owned(),
                                   generic_args: Vec::new(),
-                                  generic_types: Vec::new()
+                                  generic_types: Vec::new(),
+                                  docs: String::from(""),  //TODO: fix
+
                 });
             });
         }
@@ -809,7 +824,9 @@ pub fn resolve_path_with_str(path: &core::Path, filepath: &Path, pos: usize,
                 mtype: Builtin,
                 contextstr: "str".into(),
                 generic_args: vec![],
-                generic_types: vec![]
+                generic_types: vec![],
+                docs: String::from(""),  //TODO: fix
+
             });
         }
         
@@ -866,7 +883,10 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
                         local: false,
                         mtype: Module,
                         contextstr: cratepath.to_str().unwrap().to_owned(),
-                        generic_args: Vec::new(), generic_types: Vec::new()
+                        generic_args: Vec::new(),
+                        generic_types: Vec::new(),
+                        docs: String::from(""),  //TODO: fix
+
             });
         });
 
@@ -1060,7 +1080,9 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
                            mtype: Module,
                            contextstr: path.to_str().unwrap().to_owned(),
                            generic_args: Vec::new(),
-                           generic_types: Vec::new()
+                           generic_types: Vec::new(),
+                           docs: String::from(""),  //TODO: fix
+
                        });
         });
     } else {

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -74,7 +74,7 @@ fn get_type_of_self_arg(m: &Match, msrc: Src, session: &Session) -> Option<core:
                            contextstr: matchers::first_line(&msrc[start..]),
                            generic_args: Vec::new(),
                            generic_types: Vec::new(),
-                           docs: String::from(""),  //TODO: fix
+                           docs: String::new(),
                 }))
             })
         }

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -72,7 +72,9 @@ fn get_type_of_self_arg(m: &Match, msrc: Src, session: &Session) -> Option<core:
                            local: m.local,
                            mtype: core::MatchType::Trait,
                            contextstr: matchers::first_line(&msrc[start..]),
-                           generic_args: Vec::new(), generic_types: Vec::new()
+                           generic_args: Vec::new(),
+                           generic_types: Vec::new(),
+                           docs: String::from(""),  //TODO: fix
                 }))
             })
         }


### PR DESCRIPTION
Add function and struct docstring to `Match` type so that `complete-with-snippets` can include the docstring. Prospective fix to #415.

Make it so that `complete-with-snippets` works when used for a cli provided complete string.