### PR TITLE
Escape `;` to split the MATCHes properly

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -38,15 +38,15 @@ fn match_with_snippet_fn(m: Match, session: &core::Session, interface: Interface
     let snippet = racer::snippets::snippet_for_match(&m, session);
     match interface {
         Interface::Text =>
-            println!("MATCH {};{};{};{};{};{:?};{};{:?}",
+            println!("MATCH {};{};{};{};{};{:?};{};{}",
                         m.matchstr,
                         snippet,
                         linenum.to_string(),
                         charnum.to_string(),
                         m.filepath.to_str().unwrap(),
                         m.mtype,
-                        m.contextstr,
-                        m.docs),
+                        m.contextstr.replace(";" ,"\\;"),
+                        format!("{:?}", m.docs).replace(";" ,"\\;")),
         Interface::TabText =>
             println!("MATCH\t{}\t{}\t{}\t{}\t{}\t{:?}\t{}\t{:?}",
                         m.matchstr,
@@ -55,7 +55,7 @@ fn match_with_snippet_fn(m: Match, session: &core::Session, interface: Interface
                         charnum.to_string(),
                         m.filepath.to_str().unwrap(),
                         m.mtype,
-                        m.contextstr,
+                        m.contextstr.replace("\t", "\\t"),
                         m.docs),
     }
 }

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -650,11 +650,19 @@ fn find_doc(msrc: &str, blobend: usize) -> String {
     blob.lines()
         .rev()
         .skip(1)
-        .take_while(|line| line.trim().starts_with("///"))
+        .take_while(|line| {
+            let l = line.trim();
+            l.starts_with("///") || l.starts_with("#[")
+        })
+        .filter(|line| !line.trim().starts_with("#["))  // remove the #[flags]
         .collect::<Vec<_>>()  // These are needed because
         .iter()               // you cannot `rev`an `iter` that
         .rev()                // has already been `rev`ed.
-        .map(|line| String::from(line[3..].trim().to_owned()))  // Remove "/// "
+        .map(|line| if line.len() >= 4 {  // Remove "/// "
+                String::from(line[4..].to_owned())
+            } else {
+                String::new()
+            })
         .collect::<Vec<_>>()
         .join("\n")
 }


### PR DESCRIPTION
Both the signature and the documentation can contain the separator
character (either `;` or `\t`). Escape it so that client applications
can split the MATCHes properly.

Remove first chars from docs without losing indent.