### PR TITLE
reformat contextstr of multiline signatures

### DIFF
--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -221,6 +221,17 @@ pub fn first_line(blob: &str) -> String {
     (&blob[..blob.find('\n').unwrap_or(blob.len())]).to_owned()
 }
 
+/// Get the match's cleaned up context string
+///
+/// Strip all whitespace, including newlines in order to have a single line
+/// context string.
+pub fn get_context(blob: &str, context_end: &str) -> String {
+    (&blob[..blob.find(context_end).unwrap_or(blob.len())])
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 pub fn match_extern_crate(msrc: &str, blobstart: usize, blobend: usize,
                           searchstr: &str, filepath: &Path, search_type: SearchType,
                           session: &Session) -> Option<Match> {
@@ -357,7 +368,7 @@ pub fn match_struct(msrc: &str, blobstart: usize, blobend: usize,
             point: blobstart + start,
             local: local,
             mtype: Struct,
-            contextstr: first_line(blob),
+            contextstr: get_context(blob, "{"),
             generic_args: generics.generic_args,
             generic_types: Vec::new(),
             docs: find_doc(msrc, blobstart),
@@ -409,7 +420,7 @@ pub fn match_trait(msrc: &str, blobstart: usize, blobend: usize,
             point: blobstart + start,
             local: local,
             mtype: Trait,
-            contextstr: first_line(blob),
+            contextstr: get_context(blob, "{"),
             generic_args: Vec::new(),
             generic_types: Vec::new(),
             docs: find_doc(msrc, blobstart),
@@ -602,7 +613,7 @@ pub fn match_fn(msrc: &str, blobstart: usize, blobend: usize,
                 point: blobstart + start,
                 local: local,
                 mtype: Function,
-                contextstr: first_line(blob),
+                contextstr: get_context(blob, "{"),
                 generic_args: Vec::new(),
                 generic_types: Vec::new(),
                 docs: find_doc(msrc, blobstart),

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -326,14 +326,16 @@ fn main() { // l16
     let path = f.path();
     let pos1 = scopes::coords_to_point(src, 18, 14);  // sub::Foo::
     let cache1 = core::FileCache::new();
-    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0);
+    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0).unwrap();
     let pos2 = scopes::coords_to_point(src, 19, 7);   // t.t
     let cache2 = core::FileCache::new();
-    let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&cache2, &path, &path)).nth(0);
+    let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&cache2, &path, &path)).nth(0).unwrap();
     println!("{:?}", got1);
     println!("{:?}", got2);
-    assert_eq!(got1.unwrap().matchstr, "traitf".to_string());
-    assert_eq!(got2.unwrap().matchstr, "traitm".to_string());
+    assert_eq!(got1.matchstr, "traitf".to_string());
+    assert_eq!(got2.matchstr, "traitm".to_string());
+    assert_eq!(got1.contextstr, "fn traitf() -> bool".to_string());
+    assert_eq!(got2.contextstr, "fn traitm(&self) -> bool".to_string());
 }
 
 #[test]
@@ -355,7 +357,8 @@ fn follows_use() {
     let pos = scopes::coords_to_point(src, 5, 10);
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
-    assert_eq!(got.matchstr,"myfn".to_string());
+    assert_eq!(got.matchstr, "myfn".to_string());
+    assert_eq!(got.contextstr, "pub fn myfn()".to_string());
 }
 
 #[test]
@@ -603,6 +606,7 @@ fn finds_trait() {
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     assert_eq!(got.matchstr, "MyTrait".to_string());
+    assert_eq!(got.contextstr, "pub trait MyTrait<E: Clone>".to_string());
 }
 
 #[test]
@@ -668,7 +672,8 @@ fn finds_fn_arg_in_incomplete_fn() {
 fn finds_inline_fn() {
     let src="
     #[inline]
-    fn contains<'a>(&needle: &'a str) -> bool {
+    fn contains<'a>(&needle: &'a str)
+        -> bool {
     }
 
     contains();
@@ -679,6 +684,7 @@ fn finds_inline_fn() {
     let cache = core::FileCache::new();
     let got = find_definition(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).unwrap();
     assert_eq!(got.matchstr, "contains".to_string());
+    assert_eq!(got.contextstr, "fn contains<'a>(&needle: &'a str) -> bool".to_string());
 }
 
 #[test]
@@ -847,6 +853,43 @@ fn follows_fn_to_method() {
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
     assert_eq!("mymethod".to_string(), got.matchstr);
+}
+
+#[test]
+fn simple_struct_contextstr() {
+    let src="
+    struct Foo<T>;
+
+    fn myfn() {
+        let x: Foo
+    }
+    ";
+    let f = TmpFile::new(src);
+    let path = f.path();
+    let pos = scopes::coords_to_point(src, 5, 18);
+    let cache = core::FileCache::new();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
+    assert_eq!(got.contextstr, "struct Foo<T>;".to_string());
+}
+
+#[test]
+fn struct_contextstr() {
+    let src="
+    struct
+        Foo<T> {
+        pub fn foo1();
+    }
+
+    fn myfn() {
+        let x: Foo
+    }
+    ";
+    let f = TmpFile::new(src);
+    let path = f.path();
+    let pos = scopes::coords_to_point(src, 8, 18);
+    let cache = core::FileCache::new();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
+    assert_eq!(got.contextstr, "struct Foo<T>".to_string());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #512.

```
fn add_nums(x: i64,
            y: i64)
            -> i64 {
    x + y
}

fn main() {
    add_nums(1, 2);
}
```
Racer now returns:
```
racer complete 8 7 src/x.rs
PREFIX 4,7,add
MATCH add_nums,1,3,src/x.rs,Function,fn add_nums(x: i64, y: i64) -> i64
END
```
instead of:
```
racer complete 8 7 src/x.rs                                        {master
PREFIX 4,7,add
MATCH add_nums,1,3,src/x.rs,Function,fn add_nums(x: i64,
END
```