### PR TITLE
Remove unused import from ast.rs

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -10,7 +10,7 @@ use syntex_syntax::codemap::{self, Spanned};
 use syntex_syntax::parse::parser::Parser;
 use syntex_syntax::parse::{lexer, ParseSess};
 use syntex_syntax::print::pprust;
-use syntex_syntax::visit::{self, Visitor};
+use syntex_syntax::visit::{self};
 use syntex_syntax::errors::Handler;
 use syntex_syntax::errors::emitter::ColorConfig;
 


### PR DESCRIPTION
Hello there!

I was installing racer via cargo and noticed this unused import statement.

```
racer-1.2.9/src/racer/ast.rs:15:34: 15:41 warning: unused import, #[warn(unused_imports)] on by default
racer-1.2.9/src/racer/ast.rs:15 use syntex_syntax::visit::{self, Visitor};
```

Hope I did something useful.

Cheers!