### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ As mentioned in the command output, don't forget to add the installation directo
 
    ```racer complete std::io::B ```  (should show some completions)
 
-### Note for [rustup/multirust-rs](https://github.com/rust-lang-nursery/multirust-rs) users
+### Note for [rustup](https://github.com/rust-lang-nursery/rustup.rs) users
 
 *This does not apply to [multirust](https://github.com/brson/multirust)!*
 


### PR DESCRIPTION
I think this is clearer now. The URL actually changed and I think the project is now just called `rustup`, while `multirust` isn't maintained anymore.