### PR TITLE
prevent tmp directory remain after run tests

### DIFF
--- a/tests/system.rs
+++ b/tests/system.rs
@@ -867,7 +867,8 @@ fn finds_nested_submodule_file() {
     let basedir = PathBuf::from(tmpname());
     let srcpath = basedir.join("root.rs");
     let sub2dir = basedir.join("sub1").join("sub2");
-    let _dir = TmpDir::with_name(sub2dir.as_path().to_str().unwrap());
+    let _rootdir = TmpDir::with_name(basedir.as_path().to_str().unwrap());
+    let _dir2 = TmpDir::with_name(sub2dir.as_path().to_str().unwrap());
 
     let _src = TmpFile::with_path(&srcpath, rootsrc);
     let _src3 = TmpFile::with_path(&sub2dir.join("sub3.rs"), sub3src);


### PR DESCRIPTION
The problem:

After running `cargo test`, there will have one tmpfile directory remain
in racer directory. This is not big but annoying problem to delete them
manually.

The cause:
The directory is generated by testing function finds_nested_submodule_file.
The test will generated directory `tmpfile/sub1/sub2` with one steps, so
when the test is over, only the directory sub2 get removed.

The solution:

Instead of generate sub2 directory in one step. the upmost directory
tmpfile is generated explicitly to allow tmpfile directory being
removed.