### PR TITLE
Corrected impl lookup to search whole scope and fixed a bug with tuple/unit structs at end of scope

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -122,7 +122,8 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
                         session: &Session) -> vec::IntoIter<Match> {
     debug!("search_for_impls {}, {}, {:?}", pos, searchstr, filepath.to_str());
     let s = session.load_file(filepath);
-    let src = s.from(pos);
+    let scope_start = scopes::scope_start(s.as_src(), pos);
+    let src = s.from(scope_start);
 
     let mut out = Vec::new();
     for (start, end) in src.iter_stmts() {
@@ -143,7 +144,7 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
                                 let m = Match {
                                     matchstr: name.name.clone(),
                                     filepath: filepath.to_path_buf(),
-                                    point: pos + start + 5,
+                                    point: scope_start + start + 5,
                                     // items in trait impls have no "pub" but are
                                     // still accessible from other modules
                                     local: local || is_trait_impl,
@@ -162,7 +163,7 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
                     if include_traits && is_trait_impl {
                         let trait_path = implres.trait_path.unwrap();
                         let mut m = resolve_path(&trait_path,
-                                             filepath, pos + start, ExactMatch, TypeNamespace,
+                                             filepath, scope_start + start, ExactMatch, TypeNamespace,
                                              session).nth(0);
                         debug!("found trait |{:?}| {:?}", trait_path, m);
 

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -12,6 +12,7 @@ fn find_close<'a, A>(iter: A, open: u8, close: u8, level_end: u32) -> Option<usi
     for (count, &b) in iter.enumerate() {
         if b == close {
             if levels == level_end { return Some(count); }
+            if levels == 0 { return None; }
             levels -= 1;
         } else if b == open { levels += 1; }
     }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -386,6 +386,45 @@ fn main() { // l16
 }
 
 #[test]
+fn completes_trait_methods_when_at_scope_end() {
+    let src = "
+mod sub {
+    pub trait Trait {
+        fn traitf() -> bool;
+        fn traitm(&self) -> bool;
+    }
+
+    impl Trait for Foo {
+        fn traitf() -> bool { false }
+        fn traitm(&self) -> bool { true }
+    }
+
+    pub struct Foo(bool);
+}
+
+fn main() { // l16
+    let t = sub::Foo(true);
+    sub::Foo::
+    t.t
+}
+";
+    let f = TmpFile::new(src);
+    let path = f.path();
+    let pos1 = scopes::coords_to_point(src, 18, 14);  // sub::Foo::
+    let cache1 = core::FileCache::new();
+    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0).unwrap();
+    let pos2 = scopes::coords_to_point(src, 19, 7);   // t.t
+    let cache2 = core::FileCache::new();
+    let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&cache2, &path, &path)).nth(0).unwrap();
+    println!("{:?}", got1);
+    println!("{:?}", got2);
+    assert_eq!(got1.matchstr, "traitf".to_string());
+    assert_eq!(got2.matchstr, "traitm".to_string());
+    assert_eq!(got1.contextstr, "fn traitf() -> bool".to_string());
+    assert_eq!(got2.contextstr, "fn traitm(&self) -> bool".to_string());
+}
+
+#[test]
 fn follows_use() {
     let src1="
     pub fn myfn() {}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -355,7 +355,7 @@ mod sub {
         fn traitm(&self) -> bool;
     }
 
-    pub struct Foo(bool);
+    pub struct Foo(pub bool);
 
     impl Trait for Foo {
         fn traitf() -> bool { false }
@@ -399,7 +399,7 @@ mod sub {
         fn traitm(&self) -> bool { true }
     }
 
-    pub struct Foo(bool);
+    pub struct Foo(pub bool);
 }
 
 fn main() { // l16


### PR DESCRIPTION
This PR fixes two issues. Firstly there is an issue where racer could panic when completing on a tuple or unit struct at the end of a scope:

```
mod sub {
    impl Foo {
        pub fn two(&self) -> usize {2} 
    }
    pub struct Foo(bool);
}

fn main() { // l16
    let t = sub::Foo(true);
    t.t
}
```

Originally, if one tried to complete on `t.t`, racer would panic since it would try to find fields on the struct `Foo`, look ahead for an open/close brace and panic when it meets the `}` at the end of the Sub module. This is because of an `u32` underflow in `scopes::find_close` which has now been fixed.

Secondly, the completion at `t.t` above would still fail since racer would start searching for implementations from the `F` in `pub struct Foo(bool)` rather than from the start of the module scope. This has now been fixed and a new test has been added to cover this case.