### PR TITLE
[master] Fix bug where generic may occur in return type.

### DIFF
--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -39,7 +39,7 @@ pub fn first_param_is_self(blob: &str) -> bool {
                     let mut level = 0;
                     let mut prev = ' ';
                     let mut skip_generic = 0;
-                    for (i, c) in blob.char_indices() {
+                    for (i, c) in blob[generic_start..].char_indices() {
                         match c {
                             '<' => level += 1,
                             '>' if prev == '-' => (),
@@ -49,6 +49,7 @@ pub fn first_param_is_self(blob: &str) -> bool {
                         prev = c;
                         if level == 0 {
                             skip_generic = i;
+                            break;
                         }
                     }
                     skip_generic

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -26,31 +26,46 @@ pub fn generate_skeleton_for_parsing(src: &str) -> String {
     s
 }
 
-pub fn first_param_is_self(mut blob: &str) -> bool {
+pub fn first_param_is_self(blob: &str) -> bool {
     // skip generic arg
     // consider 'pub fn map<U, F: FnOnce(T) -> U>(self, f: F)'
     // we have to match the '>'
-    let mut skip_generic = 0;
-    if let Some(generic_start) = blob.find('<') {
-        blob = &blob[generic_start..];
-        let mut level = 0;
-        let mut prev = ' ';
-        for (i, c) in blob.char_indices() {
-            match c {
-                '<' => level+=1,
-                '>' if (prev != '-') && (level == 1) => skip_generic = i,
-                _ => (),
+    match blob.find('(') {
+        None => false,
+        Some(probable_param_start) => {
+            let skip_generic = match blob.find('<') {
+                None => 0,
+                Some(generic_start) if generic_start < probable_param_start => {
+                    let mut level = 0;
+                    let mut prev = ' ';
+                    let mut skip_generic = 0;
+                    for (i, c) in blob.char_indices() {
+                        match c {
+                            '<' => level += 1,
+                            '>' if prev == '-' => (),
+                            '>' => level -= 1,
+                            _ => (),
+                        }
+                        prev = c;
+                        if level == 0 {
+                            skip_generic = i;
+                        }
+                    }
+                    skip_generic
+                },
+                Some(..) => 0,
+            };
+            while let Some(start) = blob[skip_generic..].find('(') {
+                let end = scopes::find_closing_paren(blob, start + 1);
+                let is_self = txt_matches(ExactMatch, "self", &blob[(start + 1)..end]);
+                debug!("searching fn args: |{}| {}",
+                       &blob[(start + 1)..end],
+                       is_self);
+                return is_self;
             }
-            prev = c;
+            false
         }
-    };
-    while let Some(start) = blob[skip_generic..].find('(') {
-        let end = scopes::find_closing_paren(blob, start+1);
-        let is_self = txt_matches(ExactMatch, "self", &blob[(start+1)..end]);
-        debug!("searching fn args: |{}| {}", &blob[(start+1)..end], is_self);
-        return is_self
     }
-    false
 }
 
 #[test]


### PR DESCRIPTION
This fixes issue #575 .

This bug is in `first_param_is_self`. The function tries to see if the first parameter is `self`, hence it is a method. The function tries to skip generics before the parameter list (though I don't see why it is needed). But it did not handle the case when there is no generic in parameter list but in return type.

This is exactly the case I encountered in issue #575, when I want to auto complete a function with signature `pub fn channel_session(&self) -> Result<Channel, Error>`. In this case `first_param_is_self` finds the `<` of the return type and skips the whole parameter list.

I also fixed a bug handling nested generics along the way.