### PR TITLE
complete methods from trait in impl of trait

### DIFF
--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -285,7 +285,8 @@ pub fn get_type_from_match_arm(m: &Match, msrc: Src, session: &Session) -> Optio
 pub fn get_function_declaration(fnmatch: &Match, session: &Session) -> String {
     let src = session.load_file(&fnmatch.filepath);
     let start = scopes::find_stmt_start(src.as_src(), fnmatch.point).unwrap();
-    let end = (&src[start..]).find('{').unwrap();
+    let def_end: &[_] = &['{', ';'];
+    let end = (&src[start..]).find(def_end).unwrap();
     (&src[start..end+start]).to_owned()
 }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -504,10 +504,10 @@ fn follows_multiple_use_globs() {
     use multiple_glob_test2::*;
     mod multiple_glob_test1;
     mod multiple_glob_test2;
-    
+
     src
     ";
-    
+
     let _tmpsrc1 = TmpFile::with_name("multiple_glob_test1.rs", src1);
     let _tmpsrc2 = TmpFile::with_name("multiple_glob_test2.rs", src2);
     let tmpsrc = TmpFile::new(src);
@@ -516,7 +516,7 @@ fn follows_multiple_use_globs() {
     let cache = core::FileCache::new();
     let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path));
     let completion_strings = got.into_iter().map(|raw_match| raw_match.matchstr).collect::<Vec<_>>();
-    
+
     assert!(completion_strings.contains(&"src1fn".to_string()) && completion_strings.contains(&"src2fn".to_string()),
     format!("Results should contain BOTH \"src1fn\" and \"src2fn\". Actual returned results: {:?} ", completion_strings));
 }
@@ -1977,4 +1977,35 @@ fn completes_multiple_use_comma() {
     for (wo, wi) in gotwo.zip(gotwi) {
         assert_eq!(wo.matchstr, wi.matchstr);
     }
+}
+
+
+#[test]
+fn completes_trait_methods_in_trait_impl() {
+    let src = "
+mod sub {
+    pub trait Trait {
+        fn traitf() -> bool;
+        fn traitm(&self) -> bool;
+    }
+
+    pub struct Foo(bool);
+
+    impl Trait for Foo {
+        fn traitf() -> bool { false }
+        fn traitm(&self) -> bool { true }
+    }
+}
+";
+    let f = TmpFile::new(src);
+    let path = f.path();
+    let pos1 = scopes::coords_to_point(src, 11, 17);  // fn trait
+    let cache1 = core::FileCache::new();
+    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0).unwrap();
+    assert_eq!(got1.matchstr, "traitf".to_string());
+    assert_eq!(got1.contextstr, "fn traitf() -> bool".to_string());
+    let pos1 = scopes::coords_to_point(src, 12, 17);  // fn trait
+    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0).unwrap();
+    assert_eq!(got1.matchstr, "traitm".to_string());
+    assert_eq!(got1.contextstr, "fn traitm(&self) -> bool".to_string());
 }


### PR DESCRIPTION
makes it possible to complete and find methods from trait in the impl of that trait.
not sure how to make it work like I want to but I think this is a good first step.

I want to make it complete with the definition of the method but now it only completes the name.
e.g. 
impl fmt::Debug for Match {
   fn fm
          ^ here I want it to complete with "fn fmt(&self, &mut Formatter) -> Result" that is the definition
now it completes with fmt.
Or maybe even better if it figures out that I have no use for the fmt::{Formattter, Result} 
and return "fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result"