### PR TITLE
Added basic for loop completion for Vec (IntoIterator)

### DIFF
--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -161,6 +161,7 @@ fn get_type_of_for_expr(m: &Match, msrc: Src, session: &Session) -> Option<core:
     src.push_str(&stmt[forpos+4..inpos]);
     src.push_str(") = ");
     src.push_str(&stmt[inpos+4..bracepos]);
+    src = src.trim_right().to_owned();
     src.push_str(".into_iter().next() { }}");
     let src = core::new_source(src);
 
@@ -168,8 +169,8 @@ fn get_type_of_for_expr(m: &Match, msrc: Src, session: &Session) -> Option<core:
         let blob = &src[start..end];
         debug!("get_type_of_for_expr: |{}| {} {} {} {}", blob, m.point, stmtstart, forpos, start);
 
-        let pos = m.point - stmtstart - forpos - start;
-        let scope = Scope{ filepath: m.filepath.clone(), point: m.point };
+        let pos = m.point + 8 - stmtstart - forpos - start;
+        let scope = Scope{ filepath: m.filepath.clone(), point: m.point + 8 };
 
         ast::get_let_type(blob.to_owned(), pos, scope, session)
     } else {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -347,6 +347,44 @@ fn main() {
 }
 
 #[test]
+fn completes_for_variable_field_and_method() {
+    let src="
+    struct St
+    {
+        stfield: i32,
+    }
+    
+    impl St {
+        pub fn stmethod(&self) -> u32 {2}
+    }
+    
+    fn main()
+    {
+        let mut arr:Vec<St> = Vec::new();
+        arr.push(St {data: 4, datum: 4.0} );
+    
+        for it in arr
+        {
+            it.stf
+            it.stm  
+        }
+    }
+    ";
+    let tmp = TmpFile::new(src);
+    let path = tmp.path();
+    let pos1 = scopes::coords_to_point(src, 18, 18);
+    let cache1 = core::FileCache::new();
+    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0).unwrap();
+    println!("{:?}", got1);
+    assert_eq!("stfield".to_string(), got1.matchstr);
+    let pos2 = scopes::coords_to_point(src, 19, 18);
+    let cache2 = core::FileCache::new();
+    let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&cache2, &path, &path)).nth(0).unwrap();
+    println!("{:?}", got2);
+    assert_eq!("stmethod".to_string(), got2.matchstr);
+}
+
+#[test]
 fn completes_trait_methods() {
     let src = "
 mod sub {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -347,8 +347,43 @@ fn main() {
 }
 
 #[test]
-fn completes_for_variable_field_and_method() {
+fn completes_for_vec_field_and_method() {
+    let modsrc = "
+    pub trait IntoIterator {
+        type Item;
+        
+        type IntoIter: Iterator<Item=Self::Item>;
+        
+        fn into_iter(self) -> Self::IntoIter;
+    }
+    
+    impl<T> IntoIterator for Vec<T> {
+        type Item = T;
+        type IntoIter = IntoIter<T>;
+        
+        fn into_iter(mut self) -> IntoIter<T> {}
+    }
+    
+    pub struct IntoIter<T> {}
+    
+    impl<T> Iterator for IntoIter<T> {
+        type Item = T;
+        
+        fn next(&mut self) -> Option<T> {}
+    }
+    
+    pub struct Vec<T> {}
+
+    pub enum Option<T> {
+        None,
+        Some(T)
+    }
+    ";
     let src="
+    pub mod mymod;
+    use mymod::{Vec, IntoIter, IntoIterator, Option};
+    use Option::{Some, None};
+
     struct St
     {
         stfield: i32,
@@ -360,24 +395,28 @@ fn completes_for_variable_field_and_method() {
     
     fn main()
     {
-        let mut arr:Vec<St> = Vec::new();
-        arr.push(St {data: 4, datum: 4.0} );
+        let mut arr: Vec<St> = Vec::new();
+        arr.push( St{stfield: 4} );
     
         for it in arr
         {
             it.stf
-            it.stm  
+            it.stm
         }
     }
     ";
-    let tmp = TmpFile::new(src);
-    let path = tmp.path();
-    let pos1 = scopes::coords_to_point(src, 18, 18);
+
+    let dir = TmpDir::new();
+    let _modfile = dir.new_temp_file_with_name("mymod.rs", modsrc);
+    let srcfile = dir.new_temp_file_with_name("src.rs", src);
+    
+    let path = srcfile.path();
+    let pos1 = scopes::coords_to_point(src, 22, 18);
     let cache1 = core::FileCache::new();
     let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0).unwrap();
     println!("{:?}", got1);
     assert_eq!("stfield".to_string(), got1.matchstr);
-    let pos2 = scopes::coords_to_point(src, 19, 18);
+    let pos2 = scopes::coords_to_point(src, 23, 18);
     let cache2 = core::FileCache::new();
     let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&cache2, &path, &path)).nth(0).unwrap();
     println!("{:?}", got2);


### PR DESCRIPTION
This goes someway towards fixing #555. This PR allows for completion of fields and methods of for loop variables when using a Vec (or, in theory, anything that implements IntoIterator). 

Test example:

```
    struct St
    {
        stfield: i32,
    }
    
    impl St {
        pub fn stmethod(&self) -> u32 {2}
    }
    
    fn main()
    {
        let mut arr: Vec<St> = Vec::new();
        arr.push( St{stfield: 4} );
    
        for it in arr
        {
            it.stf
            it.stm  
        }
    }
```

racer can now complete the field and method from ``it.str``, ``it.stm``.

*What this PR Doesn't Do:* It does not complete on variables from other iterators. The blocker on this is the implementation of IntoIterator for Iterator in libcore/iter/traits.rs:

```
impl<I: Iterator> IntoIterator for I {
    type Item = I::Item;
    type IntoIter = I;

    fn into_iter(self) -> I {
        self
    }
}
```
This would require
1. racer looking up trait bounds to find potential implementations
2. racer looking outside the trait's defining file to look for implementations 
   (This is because Iterator is defined in libcore/iter/iterator.rs)

This also doesn't deal with issues with racer failing to find the generic types in cases like:
```
let mut v1 = Vec::new();
v1.push("hello".to_string());

let mut v2 = Vec::<String>::new();
```

*Regarding Tests:* The current test setup for racer does not use the Rust source code for travis builds. To get around this issue I have inserted the necessary parts of the source code into a separate &str (like with the Deref test). This hit issue #575, so please merge PR #577 before this.
