### PR TITLE
Added basic completion of iter variables in for loops

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -460,7 +460,7 @@ impl<'c, 's, 'v> visit::Visitor<'v> for ExprTypeVisitor<'c, 's> {
                         Ty::Match(ref m) =>  {
 
                             match m.mtype {
-                                MatchType::Function => typeinf::get_return_type_of_function(m, self.session)
+                                MatchType::Function => typeinf::get_return_type_of_function(m, m, self.session)
                                     .and_then(|ty| path_to_match(ty, self.session)),
                                 MatchType::Struct => Some(Ty::Match(m.clone())),
                                 _ => {
@@ -500,11 +500,12 @@ impl<'c, 's, 'v> visit::Visitor<'v> for ExprTypeVisitor<'c, 's> {
                                 &contextm.filepath,
                                 contextm.local,
                                 core::SearchType::ExactMatch,
-                                self.session).nth(0);
+                                self.session);
                             omethod
-                                .and_then(|method|
-                                          typeinf::get_return_type_of_function(&method, self.session))
-                                .and_then(|ty| path_to_match_including_generics(ty, contextm, self.session))
+                                .map(|method| typeinf::get_return_type_of_function(&method, &contextm, self.session))
+                                .filter_map(|ty| ty
+                                     .and_then(|ty| {path_to_match_including_generics(ty, contextm, self.session)}))
+                                .nth(0)
                         }
                         _ => None
                     }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -547,6 +547,186 @@ fn completes_trait_bounded_methods_generic_return() {
 }
 
 #[test]
+fn completes_iter_variable_methods() {
+    let modsrc = "
+    pub trait Iterator {
+        type Item;
+        
+        fn next(&mut self) -> Option<Self::Item>;
+    }
+
+    pub trait IntoIterator {
+        type Item;
+        
+        type IntoIter: Iterator<Item=Self::Item>;
+        
+        fn into_iter(self) -> Self::IntoIter;
+    }
+
+    impl<I: Iterator> IntoIterator for I {
+        type Item = I::Item;
+        type IntoIter = I;
+    
+        fn into_iter(self) -> I {
+            self
+        }
+    }
+
+    impl<T> Iterator for IntoIter<T> {
+        type Item = T;
+        
+        fn next(&mut self) -> Option<T> {}
+    }
+
+    pub enum Option<T> {
+        None,
+        Some(T)
+    }
+    ";
+    
+    let src = "
+    pub mod mymod;
+    use mymod::{Iterator, Option};
+    use Option::{Some, None};
+
+    struct St {
+        pub item: StItem,
+        pub used: bool
+    }
+
+    struct StItem {
+        pub field: u32
+    }
+    
+    impl Iterator for St {
+        type Item: StItem;
+    
+        fn next(&mut self) -> Option<StItem> {
+            if self.used {
+                self.used = false;
+                return Some(self.item);
+            }
+            None
+        }
+    }
+    
+    fn main()
+    {
+        let it = St {
+            text: StItem { field: 22 },
+            used: false
+        }
+        
+        for item in it {
+            item.fie
+        }
+    }
+";
+    let dir = TmpDir::new();
+    let _modfile = dir.new_temp_file_with_name("mymod.rs", modsrc);
+    let srcfile = dir.new_temp_file_with_name("src.rs", src);
+    
+    let path = srcfile.path();
+    let pos = scopes::coords_to_point(src, 35, 20);  // sub::Foo::
+    let cache = core::FileCache::new();
+    let got = complete_from_file(src, &path, pos, &core::Session::from_path(&cache, &path, &path)).nth(0).unwrap();
+    println!("{:?}", got);
+    assert_eq!(got.matchstr, "field".to_string());
+}
+
+#[test]
+fn completes_for_vec_iter_field_and_method() {
+    let modsrc = "
+    pub trait Iterator {
+        type Item;
+        
+        fn next(&mut self) -> Option<Self::Item>;
+    }
+
+    pub trait IntoIterator {
+        type Item;
+        
+        type IntoIter: Iterator<Item=Self::Item>;
+        
+        fn into_iter(self) -> Self::IntoIter;
+    }
+    
+    impl<T> IntoIterator for Vec<T> {
+        type Item = T;
+        type IntoIter = IntoIter<T>;
+        
+        fn into_iter(mut self) -> IntoIter<T> {}
+    }
+    
+    pub struct IntoIter<T> {}
+    
+    impl<T> Iterator for IntoIter<T> {
+        type Item = T;
+        
+        fn next(&mut self) -> Option<T> {}
+    }
+
+    impl<I: Iterator> IntoIterator for I {
+        type Item = I::Item;
+        type IntoIter = I;
+    
+        fn into_iter(self) -> I {
+            self
+        }
+    }
+    
+    pub struct Vec<T> {}
+
+    pub enum Option<T> {
+        None,
+        Some(T)
+    }
+    ";
+    let src="
+    pub mod mymod;
+    use mymod::{Vec, IntoIter, IntoIterator, Option};
+    use Option::{Some, None};
+
+    struct St
+    {
+        stfield: i32,
+    }
+    
+    impl St {
+        pub fn stmethod(&self) -> u32 {2}
+    }
+    
+    fn main()
+    {
+        let mut arr: Vec<St> = Vec::new();
+        arr.push( St{stfield: 4} );
+    
+        for it in arr.iter()
+        {
+            it.stf
+            it.stm
+        }
+    }
+    ";
+
+    let dir = TmpDir::new();
+    let _modfile = dir.new_temp_file_with_name("mymod.rs", modsrc);
+    let srcfile = dir.new_temp_file_with_name("src.rs", src);
+    
+    let path = srcfile.path();
+    let pos1 = scopes::coords_to_point(src, 22, 18);
+    let cache1 = core::FileCache::new();
+    let got1 = complete_from_file(src, &path, pos1, &core::Session::from_path(&cache1, &path, &path)).nth(0).unwrap();
+    println!("{:?}", got1);
+    assert_eq!("stfield".to_string(), got1.matchstr);
+    let pos2 = scopes::coords_to_point(src, 23, 18);
+    let cache2 = core::FileCache::new();
+    let got2 = complete_from_file(src, &path, pos2, &core::Session::from_path(&cache2, &path, &path)).nth(0).unwrap();
+    println!("{:?}", got2);
+    assert_eq!("stmethod".to_string(), got2.matchstr);
+}
+
+#[test]
 fn completes_trait_methods_when_at_scope_end() {
     let src = "
 mod sub {


### PR DESCRIPTION
This is a very crude implementation of step 2. from #579. It allows for completion of certain iterators variable in for loops beyond IntoIterator cases. A couple of example cases

Standard iter case for Vec:
```
fn main()
{
    let it: Vec<String> = vec!["Hello".to_string()];
    
    for item in it.iter() {
        item.le               // Will now complete the len() method from String
    }
}
```



Explicit implementation of Iterator:
```
struct St {
    pub item: StItem,
    pub used: bool
}

struct StItem {
    pub field: u32
}
    
impl Iterator for St {
    type Item: StItem;

    fn next(&mut self) -> Option<StItem> {
        if self.used {
            self.used = false;
            return Some(self.item);
        }
        None
    }
}
    
fn main()
{
    let it = St {
        text: StItem { field: 22 },
        used: false
    }
    
    for item in it {
        item.fie          // Will now complete to field from StItem
    }
}
```

*Limitations and workarounds*
* More complex uses of iterators, like zip, currently still don't work due to heavy use of associated types.

* Finding the iter() method on some built in types is near-on impossible atm. For example, for the Vec struct the iter() method is defined as a deref to a slice and the iter() method on slices is defined through the `iterator!()` macro, which would be a very tough challenge to handle (would probably have to expand the macro and store the result in a cache somewhere). I was able to handle the slice deref step but this work ultimately had to be dropped because of the macro issue.
The (hopefully temporary) workaround was to just replace iter() and iter_mut() calls to calls of into_iter(). The return types are the same (modulo references) and doesn't use a macro for implementation on built-in types.

* There is a manual file redirect from iterator.rs to traits.rs so that the following implementation can be located:
```
impl<I: Iterator> IntoIterator for I {
    type Item = I::Item;
    type IntoIter = I;

    fn into_iter(self) -> I {
        self
    }
}
```