### PR TITLE
Fix panic when trying to complete use <mod>::

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -51,7 +51,8 @@ pub fn string_to_crate(source_str: String) -> Option<ast::Crate> {
         use std::result::Result::{Ok, Err};
         match p.parse_crate_mod() {
             Ok(e) => Some(e),
-            Err(_) => {
+            Err(mut err) => {
+                err.cancel();
                 debug!("unable to parse crate. Returning None |{}|", source_str);
                 None
             }


### PR DESCRIPTION
The DiagnosticBuilder panics on drop unless the error is cancelled. This
caused racer to give up searching for a completion prematurely. Since
fixing this, completions seem to work much more frequently.

The actual problem here that's not addressed is a statement iterator is
generated and gets a statement that looks something like

    use bar::
    use foo::bar;

Where the completion is after the `use bar::`, but the end of a
statement is `;`. Parsing this fails, and a completion would never be
found in this case! Chopping off characters and reparsing until a
valid statement is parsed would fix this particular failure mode.