### PR TITLE
Remove README note about rustup.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,6 @@ As mentioned in the command output, don't forget to add the installation directo
 
    ```racer complete std::io::B ```  (should show some completions)
 
-### Note for [rustup](https://github.com/rust-lang-nursery/rustup.rs) users
-
-*This does not apply to [multirust](https://github.com/brson/multirust)!*
-
-To enable completion for cargo crates, you need to set the `CARGO_HOME` environment variable to `.cargo` in your home directory.
-
 ## Editors/IDEs Supported
 
 ### Eclipse integration


### PR DESCRIPTION
The code in question has been removed in 7455a4841e8c6d588a669329705fd8a42c230bea
so the note should go.