### PR TITLE
find method definition when field share name.

### DIFF
--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -713,10 +713,11 @@ pub fn find_definition_(src: &str, filepath: &path::Path, pos: usize, session: &
             let context = ast::get_type_of(contextstr.to_owned(), filepath, pos, session);
             debug!("context is {:?}", context);
 
+            let match_type:MatchType = if src[end..].starts_with('(') { MatchType::Function } else { MatchType::StructField };
             context.and_then(|ty| {
                 // for now, just handle matches
                 if let Ty::Match(m) = ty {
-                    nameres::search_for_field_or_method(m, searchstr, SearchType::ExactMatch, session).nth(0)
+                    nameres::search_for_field_or_method(m, searchstr, SearchType::ExactMatch, session).filter(|m| m.mtype == match_type).nth(0)
                 } else {
                     None
                 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4,6 +4,7 @@ extern crate rand;
 
 use racer::core::complete_from_file;
 use racer::core::find_definition;
+use racer::core::MatchType;
 use racer::core;
 
 use std::io::Write;
@@ -1969,7 +1970,7 @@ fn finds_self_param_when_fn_has_generic_closure_arg() {
     }
 
     let a: MyOption;
-    a.~map
+    a.~map()
     ";
 
     let got = get_definition(src, None);
@@ -2118,4 +2119,32 @@ fn completes_trait_methods_in_trait_impl() {
     let got = complete_from_file(src, &path, pos, &session).nth(0).unwrap();
     assert_eq!(got.matchstr, "traitm");
     assert_eq!(got.contextstr, "fn traitm(&self) -> bool");
+}
+
+#[test]
+fn finds_field_with_same_name_as_method() {
+    let src = "
+    struct Foo { same_name: uint }
+    impl Foo { fn same_name(&self){} }
+    let a: Foo;
+    a.same_na~me;
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("same_name", got.matchstr);
+    assert_eq!(MatchType::StructField, got.mtype);
+}
+
+#[test]
+fn finds_method_with_same_name_as_field() {
+    let src = "
+    struct Foo { same_name: uint }
+    impl Foo { fn same_name(&self){}}
+    let a: Foo;
+    a.same_na~me();
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("same_name", got.matchstr);
+    assert_eq!(MatchType::Function, got.mtype);
 }


### PR DESCRIPTION
for method calls it was not possible to find definition if a field used the same name