### PR TITLE
canonicalize path to make test pass in windows

### DIFF
--- a/src/racer/cargo.rs
+++ b/src/racer/cargo.rs
@@ -675,6 +675,7 @@ mod tests {
 
         let actual = super::get_crate_file_from_overrides("arst", start_from)
             .expect("finds arst/src/lib.rs");
-        assert_eq!(actual.canonicalize().expect("canonicalize path"), expected);
+        assert_eq!(actual.canonicalize().expect("canonicalize path"),
+         expected.canonicalize().expect("canonicalize path"));
     }
 }


### PR DESCRIPTION
the canonicalize add \\?\ at the begining of the path in windows so to make the test cargo::tests::get_crate_file_from_overrides pass in windows canonicalize needs to be on actual and expected.