### PR TITLE
Fix `use foo::bar::self;` not followed

### DIFF
--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -591,7 +591,9 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                         }
                     }
                 }
-            } else if ident == "" {   // i.e. no 'as'. e.g. 'use foo::{bar, baz}'
+            } else if ident == "" || ident == "self" {   // i.e. no 'as'. e.g. 'use foo::{bar, baz}'
+                // `use foo::bar::self;` is parsed as path = foo::bar, ident = self
+
                 // if searching for a symbol and the last path segment
                 // matches the symbol then find the fqn
                 if len == 1 && path.segments[0].name == searchstr {

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -610,14 +610,17 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                         path
                     };
 
-                    if symbol_matches(search_type, searchstr, &path.segments.last().unwrap().name) {
-                        // last path segment matches the path. find it!
-                        for m in resolve_path(&path, filepath, blobstart, ExactMatch, Namespace::Both, session) {
-                            out.push(m);
-                            if let ExactMatch = search_type  {
-                                return out;
-                            } else {
-                                break;
+                    if path.segments.len() > 1 {
+                        if symbol_matches(search_type, searchstr, &path.segments.last().unwrap().name) {
+                            // last path segment matches the path. find it!
+                            for m in resolve_path(&path, filepath, blobstart,
+                                                  ExactMatch, Namespace::Both, session) {
+                                out.push(m);
+                                if let ExactMatch = search_type  {
+                                    return out;
+                                } else {
+                                    break;
+                                }
                             }
                         }
                     }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -971,6 +971,20 @@ fn follows_use_self() {
 
     let completions = get_all_completions(src, None);
     assert!(completions.into_iter().any(|m| m.matchstr == "use_self_test"));
+
+    let src ="
+    mod foo {
+        pub mod use_self_test {
+        }
+    }
+
+    use foo::use_self_test::self;
+
+    use_s~
+    ";
+
+    let completions = get_all_completions(src, None);
+    assert!(completions.into_iter().any(|m| m.matchstr == "use_self_test"));
 }
 
 #[test]

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -958,13 +958,13 @@ fn follows_use_self() {
     let _lock = sync!();
 
     let src ="
+    use foo::use_self_test::{self, bar};
+
     mod foo {
         pub mod use_self_test {
             pub fn bar() {}
         }
     }
-
-    use foo::use_self_test::{self, bar};
 
     use_s~
     ";
@@ -973,12 +973,10 @@ fn follows_use_self() {
     assert!(completions.into_iter().any(|m| m.matchstr == "use_self_test"));
 
     let src ="
-    mod foo {
-        pub mod use_self_test {
-        }
-    }
+    use use_self_test::self;
 
-    use foo::use_self_test::self;
+    mod use_self_test {
+    }
 
     use_s~
     ";


### PR DESCRIPTION
`use foo::bar::self` is parsed as `ViewPathSimple(self, foo::bar)`.