### PR TITLE
fixes #618 and fixes #594

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -141,7 +141,7 @@ fn search_scope_for_methods(point: usize, src: Src, searchstr: &str, filepath: &
                            contextstr: signature.to_owned(),
                            generic_args: Vec::new(),
                            generic_types: Vec::new(),
-                           docs: find_doc(&scopesrc, blobstart),
+                           docs: find_doc(&scopesrc, blobstart + start),
                 };
                 out.push(m);
             }
@@ -179,7 +179,7 @@ fn search_generic_impl_scope_for_methods(point: usize, src: Src, searchstr: &str
                            contextstr: signature.to_owned(),
                            generic_args: contextm.generic_args.clone(),  // Attach impl generic args
                            generic_types: contextm.generic_types.clone(), // Attach impl generic types
-                           docs: find_doc(&scopesrc, blobstart),
+                           docs: find_doc(&scopesrc, blobstart + start),
                 };
                 out.push(m);
             }
@@ -217,7 +217,7 @@ fn search_scope_for_method_declarations(point: usize, src: Src, searchstr: &str,
                            contextstr: signature.to_owned(),
                            generic_args: Vec::new(),
                            generic_types: Vec::new(),
-                           docs: find_doc(&scopesrc, blobstart),
+                           docs: find_doc(&scopesrc, blobstart + start),
                 };
                 out.push(m);
             }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1042,6 +1042,7 @@ fn finds_external_fn_docs() {
     let src1 = "
     /// Orange
     /// juice
+    
     pub fn apple() {
         let x = 1;
     }";
@@ -1058,6 +1059,35 @@ fn finds_external_fn_docs() {
     let got = get_one_completion(src, Some(dir));
     assert_eq!("apple", got.matchstr);
     assert_eq!("Orange\njuice", got.docs);
+}
+
+#[test]
+fn issue_618() {
+    let _lock = sync!();
+
+    let src = "
+/// Orange
+/// juice
+pub fn appl~e() {
+}";
+
+    let got = get_only_completion(src, None);
+    assert_eq!("apple", got.matchstr);
+    assert_eq!("Orange\njuice", got.docs);
+}
+
+#[test]
+fn issue_594() {
+    let _lock = sync!();
+
+    let src = "
+/// Hello world
+/// (quux)
+pub fn fo~o() {}";
+
+    let got = get_only_completion(src, None);
+    assert_eq!("foo", got.matchstr);
+    assert_eq!("Hello world\n(quux)", got.docs);
 }
 
 #[test]


### PR DESCRIPTION
when the find_doc is called with a point at the line before the match the last line in the doc is missing
e.g. when fn declaration is at begining of line.
Use the match point instead to make sure the correct line is used.

also allow empty lines between doc comment and match line.