### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ As mentioned in the command output, don't forget to add the installation directo
 
 1. Fetch the Rust sourcecode
 
- a) manually from git, or download from https://www.rust-lang.org/install.html (the 'rustc' source download behind the 'source' link is the right one).
+ a) automatically via [rustup](https://www.rustup.rs/) and run `rustup component add rust-src` in order to install the source to `~/.multirust/toolchains/[your-toolchain]/lib/rustlib/src/rust/src`. Rustup will keep the sources in sync with the toolchain if you run `rustup update`.
  
- b) automatically via [rustup](https://www.rustup.rs/) and run `rustup component add rust-src` in order to install the source to `~/.multirust/toolchains/[your-toolchain]/lib/rustlib/src/rust/src`. Rustup will keep the sources in sync with the toolchain if you run `rustup update`.
+ b) manually from git, or download from https://www.rust-lang.org/install.html (the 'rustc' source download behind the 'source' link is the right one).
 
 2. Set the ```RUST_SRC_PATH``` environment variable to point to the 'src' dir in the Rust source installation
 


### PR DESCRIPTION
As of 1.14, rustup is the recommended way to install Rust.