### PR TITLE
Fix stack overflows

### DIFF
--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -11,6 +11,7 @@ use std::cmp::{min, max};
 use std::iter::{Fuse, Iterator};
 use std::rc::Rc;
 use codeiter::StmtIndicesIter;
+use matchers::PendingImports;
 
 use scopes;
 use nameres;
@@ -947,8 +948,8 @@ fn complete_from_file_(
 
             let path = Path::from_vec(is_global, v);
             for m in nameres::resolve_path(&path, filepath, pos,
-                                         SearchType::StartsWith, Namespace::Both,
-                                         session) {
+                                           SearchType::StartsWith, Namespace::Both,
+                                           session, &PendingImports::empty()) {
                 out.push(m);
             }
         },
@@ -1082,7 +1083,7 @@ pub fn find_definition_(filepath: &path::Path, cursor: Location, session: &Sessi
 
             nameres::resolve_path(&path, filepath, pos,
                                   SearchType::ExactMatch, Namespace::Both,
-                                  session).nth(0)
+                                  session, &PendingImports::empty()).nth(0)
         },
         CompletionType::Field => {
             let context = ast::get_type_of(contextstr.to_owned(), filepath, pos, session);

--- a/src/racer/matchers.rs
+++ b/src/racer/matchers.rs
@@ -1,6 +1,6 @@
 use {scopes, typeinf, ast};
 use core::{Match, PathSegment, Src, Session, Coordinate, SessionExt};
-use util::{symbol_matches, txt_matches, find_ident_end, is_ident_char, char_at};
+use util::{StackLinkedListNode, symbol_matches, txt_matches, find_ident_end, is_ident_char, char_at};
 use nameres::{get_module_file, get_crate_file, resolve_path};
 use core::SearchType::{self, StartsWith, ExactMatch};
 use core::MatchType::{self, Let, Module, Function, Struct, Type, Trait, Enum, EnumVariant,
@@ -10,6 +10,17 @@ use std::cell::Cell;
 use std::path::Path;
 use std::{iter, option, str, vec};
 
+/// The location of an import (`use` item) currently being resolved.
+#[derive(PartialEq, Eq)]
+pub struct PendingImport<'fp> {
+    filepath: &'fp Path,
+    blobstart: usize,
+    blobend: usize,
+}
+
+/// A stack of imports (`use` items) currently being resolved.
+pub type PendingImports<'stack, 'fp> = StackLinkedListNode<'stack, PendingImport<'fp>>;
+
 pub type MIter = option::IntoIter<Match>;
 pub type MChain<T> = iter::Chain<T, MIter>;
 
@@ -17,14 +28,15 @@ pub type MChain<T> = iter::Chain<T, MIter>;
 pub fn match_types(src: Src, blobstart: usize, blobend: usize,
                    searchstr: &str, filepath: &Path,
                    search_type: SearchType,
-                   local: bool, session: &Session) -> iter::Chain<MChain<MChain<MChain<MChain<MChain<MIter>>>>>, vec::IntoIter<Match>> {
+                   local: bool, session: &Session,
+                   pending_imports: &PendingImports) -> iter::Chain<MChain<MChain<MChain<MChain<MChain<MIter>>>>>, vec::IntoIter<Match>> {
     let it = match_extern_crate(&src, blobstart, blobend, searchstr, filepath, search_type, session).into_iter();
     let it = it.chain(match_mod(src, blobstart, blobend, searchstr, filepath, search_type, local, session).into_iter());
     let it = it.chain(match_struct(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
     let it = it.chain(match_type(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
     let it = it.chain(match_trait(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
     let it = it.chain(match_enum(&src, blobstart, blobend, searchstr, filepath, search_type, local).into_iter());
-    it.chain(match_use(&src, blobstart, blobend, searchstr, filepath, search_type, local, session).into_iter())
+    it.chain(match_use(&src, blobstart, blobend, searchstr, filepath, search_type, local, session, pending_imports).into_iter())
 }
 
 pub fn match_values(src: Src, blobstart: usize, blobend: usize,
@@ -523,9 +535,27 @@ thread_local!(static ALREADY_GLOBBING: Cell<Option<bool>> = Cell::new(None));
 
 pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                  searchstr: &str, filepath: &Path, search_type: SearchType,
-                 local: bool, session: &Session) -> Vec<Match> {
-    let mut out = Vec::new();
+                 local: bool, session: &Session,
+                 pending_imports: &PendingImports) -> Vec<Match> {
+    let import = PendingImport {
+        filepath: &filepath,
+        blobstart: blobstart,
+        blobend: blobend,
+    };
+
     let blob = &msrc[blobstart..blobend];
+
+    // If we're trying to resolve the same import recursively,
+    // do not return any matches this time.
+    if pending_imports.contains(&import) {
+        debug!("import {} involved in a cycle; ignoring", blob);
+        return Vec::new();
+    }
+
+    // Push this import on the stack of pending imports.
+    let pending_imports = &pending_imports.push(import);
+
+    let mut out = Vec::new();
 
     if find_keyword(blob, "use", "", StartsWith, local).is_none() { return out; }
 
@@ -554,7 +584,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                 let mut path = basepath.clone();
                 path.segments.push(seg);
                 debug!("found a glob: now searching for {:?}", path);
-                let iter_path = resolve_path(&path, filepath, blobstart, search_type, Namespace::Both, session);
+                let iter_path = resolve_path(&path, filepath, blobstart, search_type, Namespace::Both, session, pending_imports);
                 if let StartsWith = search_type {
                 	ALREADY_GLOBBING.with(|c| { c.set(None) });
                     return iter_path.collect();
@@ -582,7 +612,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                     // Do nothing because this will be picked up by the module
                     // search in a bit.
                 } else {
-                    for m in resolve_path(&path, filepath, blobstart, ExactMatch, Namespace::Both, session) {
+                    for m in resolve_path(&path, filepath, blobstart, ExactMatch, Namespace::Both, session, pending_imports) {
                         out.push(m);
                         if let ExactMatch = search_type  {
                             return out;
@@ -614,7 +644,7 @@ pub fn match_use(msrc: &str, blobstart: usize, blobend: usize,
                         if symbol_matches(search_type, searchstr, &path.segments.last().unwrap().name) {
                             // last path segment matches the path. find it!
                             for m in resolve_path(&path, filepath, blobstart,
-                                                  ExactMatch, Namespace::Both, session) {
+                                                  ExactMatch, Namespace::Both, session, pending_imports) {
                                 out.push(m);
                                 if let ExactMatch = search_type  {
                                     return out;

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -10,6 +10,7 @@ use matchers::find_doc;
 use cargo;
 use std::path::{Path, PathBuf};
 use std::{self, vec};
+use matchers::PendingImports;
 
 #[cfg(unix)]
 pub const PATH_SEP: char = ':';
@@ -62,7 +63,7 @@ pub fn search_for_impl_methods(match_request: &Match,
 
     let mut out = Vec::new();
 
-    for m in search_for_impls(point, implsearchstr, fpath, local, true, session) {
+    for m in search_for_impls(point, implsearchstr, fpath, local, true, session, &PendingImports::empty()) {
         debug!("found impl!! |{:?}| looking for methods", m);
 
         if m.matchstr == "Deref" {
@@ -228,7 +229,7 @@ fn search_scope_for_method_declarations(point: usize, src: Src, searchstr: &str,
 
 
 pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: bool, include_traits: bool,
-                        session: &Session) -> vec::IntoIter<Match> {
+                        session: &Session, pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("search_for_impls {}, {}, {:?}", pos, searchstr, filepath.display());
     let s = session.load_file(filepath);
     let scope_start = scopes::scope_start(s.as_src(), pos);
@@ -274,8 +275,8 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
                     if include_traits && is_trait_impl {
                         let trait_path = implres.trait_path.unwrap();
                         let mut m = resolve_path(&trait_path,
-                                             filepath, scope_start + start, ExactMatch, Namespace::Type,
-                                             session).nth(0);
+                                                 filepath, scope_start + start, ExactMatch, Namespace::Type,
+                                                 session, pending_imports).nth(0);
                         debug!("found trait |{:?}| {:?}", trait_path, m);
 
                         if let Some(ref mut m) = m {
@@ -364,8 +365,8 @@ pub fn search_for_generic_impls(pos: usize, searchstr: &str, contextm: &Match, f
 
 // scope headers include fn decls, if let, while let etc..
 fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &str,
-                        filepath: &Path, search_type: SearchType, session: &Session)
-                         -> vec::IntoIter<Match> {
+                        filepath: &Path, search_type: SearchType, session: &Session,
+                        pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("search_scope_headers for |{}| pt: {}", searchstr, scopestart);
     if let Some(stmtstart) = scopes::find_stmt_start(msrc, scopestart) {
         let preblock = &msrc[stmtstart..scopestart];
@@ -479,7 +480,8 @@ fn search_scope_headers(point: usize, scopestart: usize, msrc: Src, searchstr: &
                                      stmtstart + n - 1,
                                      SearchType::ExactMatch,
                                      Namespace::Both,
-                                     session)
+                                     session,
+                                     pending_imports)
                     .filter(|m| m.mtype == Trait)
                     .nth(0);
                 if let Some(m) = m {
@@ -647,7 +649,7 @@ pub fn do_file_search(
 
 pub fn search_crate_root(pathseg: &core::PathSegment, modfpath: &Path,
                          searchtype: SearchType, namespace: Namespace,
-                         session: &Session) -> vec::IntoIter<Match> {
+                         session: &Session, pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("search_crate_root |{:?}| {:?}", pathseg, modfpath.display());
 
     let crateroots = find_possible_crate_root_modules(modfpath.parent().unwrap(), session);
@@ -657,7 +659,7 @@ pub fn search_crate_root(pathseg: &core::PathSegment, modfpath: &Path,
             continue;
         }
         debug!("going to search for {:?} in crateroot {:?}", pathseg, crateroot.display());
-        for m in resolve_name(pathseg, &crateroot, 0, searchtype, namespace, session) {
+        for m in resolve_name(pathseg, &crateroot, 0, searchtype, namespace, session, pending_imports) {
             out.push(m);
             if let ExactMatch = searchtype {
                 break;
@@ -691,8 +693,8 @@ pub fn find_possible_crate_root_modules(currentdir: &Path, session: &Session) ->
 
 pub fn search_next_scope(mut startpoint: usize, pathseg: &core::PathSegment,
                          filepath:&Path, search_type: SearchType, local: bool,
-                         namespace: Namespace,
-                         session: &Session) -> vec::IntoIter<Match> {
+                         namespace: Namespace, session: &Session,
+                         pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     let filesrc = session.load_file(filepath);
     if startpoint != 0 {
         // is a scope inside the file. Point should point to the definition
@@ -704,7 +706,7 @@ pub fn search_next_scope(mut startpoint: usize, pathseg: &core::PathSegment,
             startpoint += n + 1;
         });
     }
-    search_scope(startpoint, startpoint, filesrc.as_src(), pathseg, filepath, search_type, local, namespace, session)
+    search_scope(startpoint, startpoint, filesrc.as_src(), pathseg, filepath, search_type, local, namespace, session, pending_imports)
 }
 
 pub fn get_crate_file(name: &str, from_path: &Path, session: &Session) -> Option<PathBuf> {
@@ -758,7 +760,8 @@ pub fn search_scope(start: usize, point: usize, src: Src,
                     pathseg: &core::PathSegment,
                     filepath:&Path, search_type: SearchType, local: bool,
                     namespace: Namespace,
-                    session: &Session) -> vec::IntoIter<Match> {
+                    session: &Session,
+                    pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     let searchstr = &pathseg.name;
     let mut out = Vec::new();
 
@@ -890,7 +893,7 @@ pub fn search_scope(start: usize, point: usize, src: Src,
         // There's a good chance of a match. Run the matchers
         out.extend(run_matchers_on_blob(src, start+blobstart, start+blobend,
                                         searchstr,
-                                        filepath, search_type, local, namespace, session));
+                                        filepath, search_type, local, namespace, session, pending_imports));
         if let ExactMatch = search_type {
             if !out.is_empty() {
                 return out.into_iter();
@@ -904,7 +907,7 @@ pub fn search_scope(start: usize, point: usize, src: Src,
         // There's a good chance of a match. Run the matchers
         for m in run_matchers_on_blob(src, start+blobstart, start+blobend,
                                       searchstr, filepath, search_type,
-                                      local, namespace, session).into_iter() {
+                                      local, namespace, session, pending_imports).into_iter() {
             out.push(m);
             if let ExactMatch = search_type {
                 return out.into_iter();
@@ -917,14 +920,15 @@ pub fn search_scope(start: usize, point: usize, src: Src,
 }
 
 fn run_matchers_on_blob(src: Src, start: usize, end: usize, searchstr: &str,
-                         filepath: &Path, search_type: SearchType, local: bool,
-                         namespace: Namespace, session: &Session) -> Vec<Match> {
+                        filepath: &Path, search_type: SearchType, local: bool,
+                        namespace: Namespace, session: &Session,
+                        pending_imports: &PendingImports) -> Vec<Match> {
     let mut out = Vec::new();
     match namespace {
         Namespace::Type =>
             for m in matchers::match_types(src, start,
                                            end, searchstr,
-                                           filepath, search_type, local, session) {
+                                           filepath, search_type, local, session, pending_imports) {
                 out.push(m);
                 if let ExactMatch = search_type {
                     return out;
@@ -942,7 +946,7 @@ fn run_matchers_on_blob(src: Src, start: usize, end: usize, searchstr: &str,
         Namespace::Both => {
             for m in matchers::match_types(src, start,
                                            end, searchstr,
-                                           filepath, search_type, local, session) {
+                                           filepath, search_type, local, session, pending_imports) {
                 out.push(m);
                 if let ExactMatch = search_type {
                     return out;
@@ -963,21 +967,21 @@ fn run_matchers_on_blob(src: Src, start: usize, end: usize, searchstr: &str,
 
 fn search_local_scopes(pathseg: &core::PathSegment, filepath: &Path,
                        msrc: Src, point: usize, search_type: SearchType,
-                       namespace: Namespace,
-                       session: &Session) -> vec::IntoIter<Match> {
+                       namespace: Namespace, session: &Session,
+                       pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("search_local_scopes {:?} {:?} {} {:?} {:?}", pathseg, filepath.display(), point,
            search_type, namespace);
 
     if point == 0 {
         // search the whole file
-        search_scope(0, 0, msrc, pathseg, filepath, search_type, true, namespace, session)
+        search_scope(0, 0, msrc, pathseg, filepath, search_type, true, namespace, session, pending_imports)
     } else {
         let mut out = Vec::new();
         let mut start = point;
         // search each parent scope in turn
         while start > 0 {
             start = scopes::scope_start(msrc, start);
-            for m in search_scope(start, point, msrc, pathseg, filepath, search_type, true, namespace, session) {
+            for m in search_scope(start, point, msrc, pathseg, filepath, search_type, true, namespace, session, pending_imports) {
                 out.push(m);
                 if let ExactMatch = search_type {
                     return out.into_iter();
@@ -990,7 +994,7 @@ fn search_local_scopes(pathseg: &core::PathSegment, filepath: &Path,
             let searchstr = &pathseg.name;
 
             // scope headers = fn decls, if let, match, etc..
-            for m in search_scope_headers(point, start, msrc, searchstr, filepath, search_type, session) {
+            for m in search_scope_headers(point, start, msrc, searchstr, filepath, search_type, session, pending_imports) {
                 out.push(m);
                 if let ExactMatch = search_type {
                     return out.into_iter();
@@ -1002,7 +1006,8 @@ fn search_local_scopes(pathseg: &core::PathSegment, filepath: &Path,
 }
 
 pub fn search_prelude_file(pathseg: &core::PathSegment, search_type: SearchType,
-                           namespace: Namespace, session: &Session) -> vec::IntoIter<Match> {
+                           namespace: Namespace, session: &Session,
+                           pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("search_prelude file {:?} {:?} {:?}", pathseg, search_type, namespace);
     let mut out : Vec<Match> = Vec::new();
 
@@ -1019,7 +1024,7 @@ pub fn search_prelude_file(pathseg: &core::PathSegment, search_type: SearchType,
         if filepath.exists() || session.contains_file(&filepath) {
             let msrc = session.load_file_and_mask_comments(&filepath);
             let is_local = true;
-            for m in search_scope(0, 0, msrc.as_src(), pathseg, &filepath, search_type, is_local, namespace, session) {
+            for m in search_scope(0, 0, msrc.as_src(), pathseg, &filepath, search_type, is_local, namespace, session, pending_imports) {
                 out.push(m);
             }
         }
@@ -1040,7 +1045,7 @@ pub fn resolve_path_with_str(path: &core::Path, filepath: &Path, pos: usize,
 
         if let Some(module) = resolve_path(&core::Path::from_vec(true, vec!["std","str"]),
                                            filepath, pos, search_type, namespace,
-                                           session).nth(0) {
+                                           session, &PendingImports::empty()).nth(0) {
             out.push(Match {
                 matchstr: "str".into(),
                 filepath: module.filepath,
@@ -1057,7 +1062,7 @@ pub fn resolve_path_with_str(path: &core::Path, filepath: &Path, pos: usize,
         }
 
     } else {
-        for m in resolve_path(path, filepath, pos, search_type, namespace, session) {
+        for m in resolve_path(path, filepath, pos, search_type, namespace, session, &PendingImports::empty()) {
             out.push(m);
             if let ExactMatch = search_type {
                 break;
@@ -1076,7 +1081,7 @@ pub struct Search {
 
 pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
                     search_type: SearchType, namespace: Namespace,
-                    session: &Session) -> vec::IntoIter<Match> {
+                    session: &Session, pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     let mut out = Vec::new();
     let searchstr = &pathseg.name;
 
@@ -1116,7 +1121,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
         }
     }
 
-    for m in search_local_scopes(pathseg, filepath, msrc.as_src(), pos, search_type, namespace, session) {
+    for m in search_local_scopes(pathseg, filepath, msrc.as_src(), pos, search_type, namespace, session, pending_imports) {
         out.push(m);
         if let ExactMatch = search_type {
             if !out.is_empty() {
@@ -1125,7 +1130,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
         }
     }
 
-    for m in search_crate_root(pathseg, filepath, search_type, namespace, session) {
+    for m in search_crate_root(pathseg, filepath, search_type, namespace, session, pending_imports) {
         out.push(m);
         if let ExactMatch = search_type {
             if !out.is_empty() {
@@ -1134,7 +1139,7 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
         }
     }
 
-    for m in search_prelude_file(pathseg, search_type, namespace, session) {
+    for m in search_prelude_file(pathseg, search_type, namespace, session, pending_imports) {
         out.push(m);
         if let ExactMatch = search_type {
             if !out.is_empty() {
@@ -1152,7 +1157,8 @@ pub fn resolve_name(pathseg: &core::PathSegment, filepath: &Path, pos: usize,
 }
 
 // Get the scope corresponding to super::
-pub fn get_super_scope(filepath: &Path, pos: usize, session: &Session) -> Option<core::Scope> {
+pub fn get_super_scope(filepath: &Path, pos: usize, session: &Session,
+                       pending_imports: &PendingImports) -> Option<core::Scope> {
     let msrc = session.load_file_and_mask_comments(filepath);
     let mut path = scopes::get_local_module_path(msrc.as_src(), pos);
     debug!("get_super_scope: path: {:?} filepath: {:?} {} {:?}", path, filepath, pos, session);
@@ -1180,7 +1186,7 @@ pub fn get_super_scope(filepath: &Path, pos: usize, session: &Session) -> Option
         let path = core::Path::from_svec(false, path);
         debug!("get_super_scope looking for local scope {:?}", path);
         resolve_path(&path, filepath, 0, SearchType::ExactMatch,
-                            Namespace::Type, session).nth(0)
+                            Namespace::Type, session, pending_imports).nth(0)
             .and_then(|m| msrc[m.point..].find('{')
                       .map(|p| core::Scope{ filepath: filepath.to_path_buf(),
                                              point:m.point + p + 1 }))
@@ -1189,28 +1195,28 @@ pub fn get_super_scope(filepath: &Path, pos: usize, session: &Session) -> Option
 
 pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                     search_type: SearchType, namespace: Namespace,
-                    session: &Session) -> vec::IntoIter<Match> {
+                    session: &Session, pending_imports: &PendingImports) -> vec::IntoIter<Match> {
     debug!("resolve_path {:?} {:?} {} {:?}", path, filepath.display(), pos, search_type);
     let len = path.segments.len();
     if len == 1 {
         let pathseg = &path.segments[0];
-        resolve_name(pathseg, filepath, pos, search_type, namespace, session)
+        resolve_name(pathseg, filepath, pos, search_type, namespace, session, pending_imports)
     } else if len != 0 {
         if path.segments[0].name == "self" {
             // just remove self
             let mut newpath: core::Path = path.clone();
             newpath.segments.remove(0);
-            return resolve_path(&newpath, filepath, pos, search_type, namespace, session);
+            return resolve_path(&newpath, filepath, pos, search_type, namespace, session, pending_imports);
         }
 
         if path.segments[0].name == "super" {
-            if let Some(scope) = get_super_scope(filepath, pos, session) {
+            if let Some(scope) = get_super_scope(filepath, pos, session, pending_imports) {
                 debug!("PHIL super scope is {:?}", scope);
 
                 let mut newpath: core::Path = path.clone();
                 newpath.segments.remove(0);
                 return resolve_path(&newpath, &scope.filepath,
-                                    scope.point, search_type, namespace, session);
+                                    scope.point, search_type, namespace, session, pending_imports);
             } else {
                 // can't find super scope. Return no matches
                 debug!("can't resolve path {:?}, returning no matches", path);
@@ -1221,7 +1227,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
         let mut out = Vec::new();
         let mut parent_path: core::Path = path.clone();
         parent_path.segments.remove(len-1);
-        let context = resolve_path(&parent_path, filepath, pos, ExactMatch, Namespace::Type, session).nth(0);
+        let context = resolve_path(&parent_path, filepath, pos, ExactMatch, Namespace::Type, session, pending_imports).nth(0);
         context.map(|m| {
             match m.mtype {
                 Module => {
@@ -1234,7 +1240,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                     }
                     let pathseg = core::PathSegment{name: searchstr.to_owned(), types: Vec::new()};
                     debug!("searching a module '{}' for {} (whole path: {:?})", m.matchstr, pathseg.name, path);
-                    for m in search_next_scope(m.point, &pathseg, &m.filepath, search_type, false, namespace, session) {
+                    for m in search_next_scope(m.point, &pathseg, &m.filepath, search_type, false, namespace, session, pending_imports) {
                         out.push(m);
                     }
                 }
@@ -1257,14 +1263,14 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                 }
                 Struct => {
                     debug!("found a struct. Now need to look for impl");
-                    for m_impl in search_for_impls(m.point, &m.matchstr, &m.filepath, m.local, true, session) {
+                    for m_impl in search_for_impls(m.point, &m.matchstr, &m.filepath, m.local, true, session, pending_imports) {
                         debug!("found impl!! {:?}", m_impl);
                         let pathseg = &path.segments[len-1];
                         let src = session.load_file(&m_impl.filepath);
                         // find the opening brace and skip to it.
                         src[m_impl.point..].find('{').map(|n| {
                             let point = m_impl.point + n + 1;
-                            for m_impl in search_scope(point, point, src.as_src(), pathseg, &m_impl.filepath, search_type, m_impl.local, namespace, session) {
+                            for m_impl in search_scope(point, point, src.as_src(), pathseg, &m_impl.filepath, search_type, m_impl.local, namespace, session, pending_imports) {
                                 out.push(m_impl);
                             }
                         });
@@ -1275,7 +1281,7 @@ pub fn resolve_path(path: &core::Path, filepath: &Path, pos: usize,
                             // find the opening brace and skip to it.
                             src[m_gen.point..].find('{').map(|n| {
                                 let point = m_gen.point + n + 1;
-                                for m_gen in search_scope(point, point, src.as_src(), pathseg, &m_gen.filepath, search_type, m_gen.local, namespace, session) {
+                                for m_gen in search_scope(point, point, src.as_src(), pathseg, &m_gen.filepath, search_type, m_gen.local, namespace, session, pending_imports) {
                                     out.push(m_gen);
                                 }
                             });
@@ -1304,7 +1310,7 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
         let pathseg = core::PathSegment{name: searchstr.to_owned(),
                                          types: Vec::new()};
 
-        for m in search_next_scope(pos, &pathseg, filepath, search_type, false, namespace, session) {
+        for m in search_next_scope(pos, &pathseg, filepath, search_type, false, namespace, session, &PendingImports::empty()) {
             out.push(m);
         }
 
@@ -1327,6 +1333,7 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
         let parent_path = &path[..(path.len()-1)];
         let context = do_external_search(parent_path, filepath, pos, ExactMatch, Namespace::Type, session).nth(0);
         context.map(|m| {
+            let pending_imports = &PendingImports::empty();
             match m.mtype {
                 Module => {
                     debug!("found an external module {}", m.matchstr);
@@ -1337,14 +1344,14 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
                     };
                     let pathseg = core::PathSegment{name: searchstr.to_owned(),
                                          types: Vec::new()};
-                    for m in search_next_scope(m.point, &pathseg, &m.filepath, search_type, false, namespace, session) {
+                    for m in search_next_scope(m.point, &pathseg, &m.filepath, search_type, false, namespace, session, pending_imports) {
                         out.push(m);
                     }
                 }
 
                 Struct => {
                     debug!("found a pub struct. Now need to look for impl");
-                    for m in search_for_impls(m.point, &m.matchstr, &m.filepath, m.local, false, session) {
+                    for m in search_for_impls(m.point, &m.matchstr, &m.filepath, m.local, false, session, pending_imports) {
                         debug!("found  impl2!! {}", m.matchstr);
                         // deal with started with "{", so that "foo::{bar" will be same as "foo::bar"
                         let searchstr = match path[path.len()-1].chars().next() {
@@ -1354,7 +1361,7 @@ pub fn do_external_search(path: &[&str], filepath: &Path, pos: usize, search_typ
                         let pathseg = core::PathSegment{name: searchstr.to_owned(),
                                          types: Vec::new()};
                         debug!("about to search impl scope...");
-                        for m in search_next_scope(m.point, &pathseg, &m.filepath, search_type, m.local, namespace, session) {
+                        for m in search_next_scope(m.point, &pathseg, &m.filepath, search_type, m.local, namespace, session, pending_imports) {
                             out.push(m);
                         }
                     };

--- a/src/racer/util.rs
+++ b/src/racer/util.rs
@@ -346,3 +346,50 @@ pub fn check_rust_src_env_var() -> ::std::result::Result<(), RustSrcPathError> {
         }
     }
 }
+
+/// An immutable stack implemented as a linked list backed by a thread's stack.
+pub struct StackLinkedListNode<'stack, T>(Option<StackLinkedListNodeData<'stack, T>>)
+    where T: 'stack;
+
+struct StackLinkedListNodeData<'stack, T>
+    where T: 'stack
+{
+    item: T,
+    previous: &'stack StackLinkedListNode<'stack, T>,
+}
+
+impl<'stack, T> StackLinkedListNode<'stack, T>
+    where T: 'stack
+{
+    /// Returns an empty node.
+    pub fn empty() -> Self {
+        StackLinkedListNode(None)
+    }
+
+    /// Pushes a new node on the stack. Returns the new node.
+    pub fn push(&'stack self, item: T) -> Self {
+        StackLinkedListNode(Some(StackLinkedListNodeData {
+            item: item,
+            previous: self,
+        }))
+    }
+}
+
+impl<'stack, T> StackLinkedListNode<'stack, T>
+    where T: 'stack + PartialEq
+{
+    /// Check if the stack contains the specified item.
+    /// Returns `true` if the item is found, or `false` if it's not found.
+    pub fn contains(&self, item: &T) -> bool {
+        let mut current = self;
+        while let &StackLinkedListNode(Some(StackLinkedListNodeData { item: ref current_item, previous })) = current {
+            if current_item == item {
+                return true;
+            }
+
+            current = previous;
+        }
+
+        false
+    }
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1041,6 +1041,56 @@ fn completes_out_of_order_mod_use_with_same_fn_name_as_mod() {
 }
 
 #[test]
+fn ignores_self_referential_unresolved_import() {
+    let _lock = sync!();
+
+    let src = "use foo::foo;f~";
+
+    let completions = get_all_completions(src, None);
+    assert!(!completions.iter().any(|m| m.matchstr == "foo"));
+}
+
+#[test]
+fn ignores_self_referential_unresolved_import_long() {
+    let _lock = sync!();
+
+    let src = "use foo::bar::foo;f~";
+
+    let completions = get_all_completions(src, None);
+    assert!(!completions.iter().any(|m| m.matchstr == "foo"));
+}
+
+#[test]
+fn ignores_self_referential_unresolved_imports() {
+    let _lock = sync!();
+
+    let src = "
+    use foo::bar;
+    use bar::baz;
+    use baz::foo;
+    f~";
+
+    let completions = get_all_completions(src, None);
+    assert!(!completions.iter().any(|m| m.matchstr == "foo"));
+}
+
+#[test]
+fn ignores_self_referential_unresolved_imports_across_modules() {
+    let _lock = sync!();
+
+    let src = "
+    use foo::bar;
+
+    mod foo {
+        pub use super::bar;
+    }
+    b~";
+
+    let completions = get_all_completions(src, None);
+    assert!(!completions.iter().any(|m| m.matchstr == "bar"));
+}
+
+#[test]
 fn finds_external_mod_docs() {
     let _lock = sync!();
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2071,6 +2071,24 @@ fn finds_glob_imported_enum_variant() {
 }
 
 #[test]
+fn finds_enum_variant_through_recursive_glob_imports() {
+    let _lock = sync!();
+
+    let src = "
+    use foo::*;
+    use Bar::*;
+
+    mod foo {
+        pub enum Bar { MyVariant, MyVariant2 }
+    }
+    MyVa~riant
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("MyVariant", got.matchstr);
+}
+
+#[test]
 #[ignore]
 fn uses_generic_arg_to_resolve_trait_method() {
     let _lock = sync!();


### PR DESCRIPTION
This is my attempt at fixing the infamous stack overflows (#354). They were crashing the Rust Language Server in my project and I don't like dirty workarounds. 😄

The first commit fixes the legitimate case where an import references a value (function, const, static, etc.) that has the same name as the first component in the import's path. For example:

```rust
use foo::foo;

mod foo {
    pub fn foo() {}
}
```

Racer will now report both the module and the function where applicable.

The second commit fixes unresolvable imports that refer to themselves, as mentioned in https://github.com/phildawes/racer/issues/354#issuecomment-134847072. For example:

```rust
use foo::foo;
// no `foo` defined anywhere
```

To fix this, we now keep track of the imports that are being resolved, and we ignore imports that are being resolved recursively. This has the effect that none of the names in such imports will be reported.

The third commit rolls back a workaround for glob imports causing stack overflows when they were processed recursively. I didn't figure out what caused the condition in the first place, but I suspect that the first two commits would fix it. It also removes the special case of a glob import referencing itself, because the second commit will take care of unbounded recursion.