### PR TITLE
Update atom racer package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ You can find more info about Visual Studio Code extension [here](https://github.
 
 ### Atom integration 
 
-You can find the racer package for Atom [here](https://atom.io/packages/racer)
+You can find the racer package for Atom [here](https://atom.io/packages/autocomplete-racer)


### PR DESCRIPTION
The current link leads to an old unmaintained and broken atom package.
Luckily there is a good alternative.