### PR TITLE
Expose MatchIter

### DIFF
--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -29,7 +29,7 @@ mod cargo;
 
 pub use core::{find_definition, complete_from_file, complete_fully_qualified_name};
 pub use snippets::snippet_for_match;
-pub use core::{Match, MatchType, PathSearch};
+pub use core::{Match, MatchType, PathSearch, MatchIter};
 pub use core::{FileCache, Session, Coordinate, Location, FileLoader};
 pub use util::expand_ident;
 


### PR DESCRIPTION
I'm trying to contribute to RLS and got stumbled around `MatchIter` and that it's private.
Exposure of `MatchIter` is important for others who want to import racer and use it in their code and create wrappers around it, I also noticed that all return types of the exposed functions from `core` are public, except this poor type.