### PR TITLE
Prevent panic on macros called 'impl*'

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -239,7 +239,8 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
     for (start, end) in src.iter_stmts() {
         let blob = &src[start..end];
 
-        if blob.starts_with("impl") {
+        if blob.starts_with("impl")
+            && !blob.contains('!') {
             blob.find('{').map(|n| {
                 let mut decl = blob[..n+1].to_owned();
                 decl.push_str("}");


### PR DESCRIPTION
Racer panics if it tries to find impls in a file like [this one in breeze-emu](https://github.com/jonas-schievink/breeze-emu/blob/2c467b8312fa2baf9edc48e66ccbab7f829c3c3b/src/breeze_core/ppu/mod.rs). Changed search_for_impls to exclude macros like search_for_generic_impls.