### PR TITLE
Fix handling of macros named '!'

### DIFF
--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -240,10 +240,15 @@ pub fn search_for_impls(pos: usize, searchstr: &str, filepath: &Path, local: boo
     for (start, end) in src.iter_stmts() {
         let blob = &src[start..end];
 
-        if blob.starts_with("impl")
-            && !blob.contains('!') {
+        if blob.starts_with("impl") {
             blob.find('{').map(|n| {
-                let mut decl = blob[..n+1].to_owned();
+                let ref decl = blob[..n+1];
+                if decl.contains('!') {
+                    // Guard against macros
+                    debug!("impl was probably a macro: {} {}", filepath.display(), start);
+                    return;
+                }
+                let mut decl = decl.to_owned();
                 decl.push_str("}");
                 if txt_matches(ExactMatch, searchstr, &decl) {
                     debug!("impl decl {}", decl);
@@ -318,10 +323,15 @@ pub fn search_for_generic_impls(pos: usize, searchstr: &str, contextm: &Match, f
     for (start, end) in src.iter_stmts() {
         let blob = &src[start..end];
 
-        if blob.starts_with("impl")
-            && !blob.contains('!') { // Guard against macros
+        if blob.starts_with("impl") {
             blob.find('{').map(|n| {
-                let mut decl = blob[..n+1].to_owned();
+                let ref decl = blob[..n+1];
+                if decl.contains('!') {
+                    // Guard against macros
+                    debug!("impl was probably a macro: {} {}", filepath.display(), start);
+                    return;
+                }
+                let mut decl = decl.to_owned();
                 decl.push_str("}");
                 let generics = ast::parse_generics(decl.clone());
                 let implres = ast::parse_impl(decl.clone());

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2817,6 +2817,42 @@ fn closure_scope_with_types() {
 }
 
 #[test]
+fn finds_impl_with_bang() {
+    let _lock = sync!();
+
+    let src = "
+    struct Foo;
+    impl Foo {
+        fn invert(&self, b: bool) -> bool { !b }
+
+        fn tst(&self) -> bool {
+            self.inv~ert(false)
+        }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("invert", got.matchstr);
+}
+
+#[test]
+fn ignores_impl_macro() {
+    let _lock = sync!();
+
+    let src = "
+    struct Foo;
+    impl!(Foo);
+
+    impl Foo {
+        fn tst(&self) -> bool {
+            self.ts~t()
+        }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("tst", got.matchstr);
+}
+
+#[test]
 fn closure_scope_find_outside() {
     let _lock = sync!();
 


### PR DESCRIPTION
Previously Racer was very aggressive about rejecting things that looked like a macro named `impl!`. However, this would result in Racer rejecting legitimate `impls` like the following:

```rust
impl Inverter {
  pub fn invert(&self, b: bool) -> bool {
    !b
  }
}
```

Fixes #716.