### PR TITLE
Completions for reference fields

### DIFF
--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -634,6 +634,13 @@ fn find_type_match_including_generics(fieldtype: &core::Ty,
     assert_eq!(&structm.filepath, filepath);
     let fieldtypepath = match *fieldtype {
         Ty::PathSearch(ref path, _) => path,
+        Ty::RefPtr(ref ty) => match *ty.as_ref() {
+            Ty::PathSearch(ref path, _) => path,
+            _ => {
+                debug!("EXPECTING A PATH!! Cannot handle other types yet. {:?}", fieldtype);
+                return None
+            }
+        },
         _ => {
             debug!("EXPECTING A PATH!! Cannot handle other types yet. {:?}", fieldtype);
             return None

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2400,6 +2400,26 @@ fn completes_methods_on_deref_type() {
 }
 
 #[test]
+fn finds_type_of_struct_field_reference() {
+    let _lock = sync!();
+
+    let src = "
+    struct Dolor { sit: u8 }
+
+    struct Lorem<'a> { ipsum: &'a Dolor }
+
+    impl<'a> Lorem<'a> {
+        fn sit(&self) {
+            let _ = self.ipsum.s~it;
+        }
+    }
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("sit", got.matchstr);
+}
+
+#[test]
 fn finds_self_param_when_fn_has_generic_closure_arg() {
     let _lock = sync!();
 


### PR DESCRIPTION
This change will look through references to get the underlying type and provide completions off that, addressing #719.