### PR TITLE
Find field types when bound through let exprs on struct fields

### DIFF
--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -67,10 +67,10 @@ impl<'a,I> Iterator for StmtIndicesIter<'a,I>
                     b'(' => { parenlevel += 1; },
                     b')' => { parenlevel -= 1; },
                     b'{' => {
-                        // if we are top level and stmt is not a 'use' then
+                        // if we are top level and stmt is not a 'use' or 'let' then
                         // closebrace finishes the stmt
                         if bracelevel == 0 && parenlevel == 0
-                            && !is_a_use_stmt(src_bytes, start, pos) {
+                            && !(is_a_use_stmt(src_bytes, start, pos) || is_a_let_stmt(src_bytes, start, pos)) {
                             enddelim = b'}';
                         }
                         bracelevel += 1;
@@ -114,6 +114,11 @@ fn is_a_use_stmt(src_bytes: &[u8], start: usize, pos: usize) -> bool {
      whitespace.contains(&src_bytes[start+3])) ||
     (pos > 7 && &src_bytes[start..(start+7)] == b"pub use" &&
      whitespace.contains(&src_bytes[start+7]))
+}
+
+fn is_a_let_stmt(src_bytes: &[u8], start: usize, pos: usize) -> bool {
+    let whitespace = b" {\t\r\n";
+    pos > 3 && &src_bytes[start..start+3] == b"let" && whitespace.contains(&src_bytes[start+3])
 }
 
 impl<'a, I> StmtIndicesIter<'a,I>

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -78,15 +78,19 @@ pub fn find_let_start(msrc: Src, point: usize) -> Option<usize> {
         let_start = msrc.from(scopestart).iter_stmts()
             .find(|&(_, end)| scopestart + end > point);
 
-        if let_start.is_some() {
-            break;
-        } else {
-            debug!("find_let_start failed to find start on attempt {}: Restarting search from {} ({:?})",
-                step,
-                scopestart - 1,
-                msrc.src.point_to_coords(scopestart - 1));
-            scopestart = scope_start(msrc, scopestart - 1);
+        if let Some((ref start, ref end)) = let_start {
+            // Check if we've actually reached the start of the "let" stmt.
+            let stmt = &msrc.src.code[(scopestart+start)..(scopestart+end)];
+            if stmt.starts_with("let") {
+                break;
+            }
         }
+        
+        debug!("find_let_start failed to find start on attempt {}: Restarting search from {} ({:?})",
+            step,
+            scopestart - 1,
+            msrc.src.point_to_coords(scopestart - 1));
+        scopestart = scope_start(msrc, scopestart - 1);
     }
 
     let_start.map(|(start, _)| scopestart + start)

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -137,7 +137,7 @@ fn get_type_of_fnarg(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty
 
 fn get_type_of_let_expr(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {
     // ASSUMPTION: this is being called on a let decl
-    let point = scopes::find_stmt_start(msrc, m.point).unwrap();
+    let point = scopes::find_let_start(msrc, m.point).unwrap();
     let src = msrc.from(point);
 
     if let Some((start, end)) = src.iter_stmts().next() {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -2014,6 +2014,22 @@ fn finds_type_of_tuple_member_via_let_expr() {
 }
 
 #[test]
+fn finds_type_of_struct_member_via_let_expr() {
+    let _lock = sync!();
+
+    let src = "
+    pub struct Blah { subfield: uint }
+    pub struct Foo { field: Blah }
+
+    let Foo { ref field } = Foo { field: Blah { subfield: 1 }};
+    field.subfi~eld
+    ";
+
+    let got = get_definition(src, None);
+    assert_eq!("subfield", got.matchstr);
+}
+
+#[test]
 fn finds_type_of_tuple_member_via_fn_retval() {
     let _lock = sync!();
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -679,7 +679,7 @@ fn completes_iter_variable_methods() {
         let it = St {
             text: StItem { field: 22 },
             used: false
-        }
+        };
 
         for item in it {
             item.fie~


### PR DESCRIPTION
This fixes #720 by improving how Racer identifies the start of `let` expressions. Specifically, it will keep looking for the statement start until it finds a statement that begins `let ...` up to a limit of 6 attempts.