### PR TITLE
Add get-type command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/scopes
 *.racertmp
 target/
 *.py[cod]
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache: cargo
 before_script:
   - pip install 'travis-cargo<0.2' --user
   - export PATH=$HOME/.local/bin:$PATH
+  - rustup component add rust-src
+  - export RUST_SRC_PATH=`rustc --print sysroot`/lib/rustlib/src/rust/src
 
 script:
   - travis-cargo --skip nightly-2016-11-25 test

--- a/src/racer/core.rs
+++ b/src/racer/core.rs
@@ -1102,6 +1102,57 @@ pub fn find_definition_(filepath: &path::Path, cursor: Location, session: &Sessi
     }
 }
 
+/// Gets the type of a variable or field identified by position in the input file.
+///
+/// When the cursor is placed anywhere inside a fully-typed identifier, this function
+/// will attempt to determine the concrete type of that value.
+pub fn get_type<P, C>(
+    filepath: P,
+    cursor: C,
+    session: &Session
+) -> Option<Match> where P: AsRef<path::Path>, C: Into<Location> 
+{
+    let fpath = filepath.as_ref();
+    let cursor = cursor.into();
+    let src = session.load_file_and_mask_comments(fpath);
+    let src = &src.as_src()[..];
+
+    // TODO return result
+    let pos = match cursor.to_point(&session.load_file(fpath)) {
+        Some(pos) => pos,
+        None => {
+            debug!("Failed to convert cursor to point");
+            return None;
+        }
+    };
+
+    /// Backtrack to find the start of the expression, like completion does. This should
+    /// enable get-type to work with field accesses as well as local variables.
+    let start = scopes::get_start_of_search_expr(src, pos);
+
+    /// Unlike `complete`, we are doing an exact match, so we also need to search forward
+    /// to find the end of the identifier. We deliberately don't look for the end of the
+    /// expression, as we aren't trying to find the whole expression's type.
+    let end = scopes::get_end_of_ident(src, pos);
+
+
+    let expr = &src[start..end];
+
+    ast::get_type_of(expr.to_owned(), fpath, pos, session).and_then(|ty| {
+        if let Ty::Match(mut m) = ty {
+            if m.coords.is_none() {
+                let point = m.point;
+                let src = session.load_file(m.filepath.as_path());
+                m.coords = src.point_to_coords(point);
+            }
+
+            Some(m)
+        } else {
+            None
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -28,7 +28,7 @@ mod matchers;
 mod snippets;
 mod cargo;
 
-pub use core::{find_definition, complete_from_file, complete_fully_qualified_name};
+pub use core::{find_definition, complete_from_file, complete_fully_qualified_name, get_type};
 pub use snippets::snippet_for_match;
 pub use core::{Match, MatchType, PathSearch};
 pub use core::{FileCache, Session, Coordinate, Location, FileLoader};

--- a/src/racer/scopes.rs
+++ b/src/racer/scopes.rs
@@ -202,6 +202,18 @@ pub fn get_line(src: &str, point: usize) -> usize {
     0
 }
 
+/// Search forward to the end of the current ident.
+/// Used by `get-type` to ensure that it is searching for the full ident rather than a prefix match.
+pub fn get_end_of_ident(src: &str, point: usize) -> usize {
+    for (i, _) in src.as_bytes()[point..].iter().enumerate() {
+        if !util::is_ident_char(char_at(src, point + i)) {
+            return point + i;
+        }
+    }
+
+    return point + src.as_bytes()[point..].len();
+}
+
 /// search in reverse for the start of the current expression 
 /// allow . and :: to be surrounded by white chars to enable multi line call chains 
 pub fn get_start_of_search_expr(src: &str, point: usize) -> usize {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -150,7 +150,7 @@ impl Drop for TmpDir {
 }
 
 fn get_pos_and_source(src: &str) -> (usize, String) {
-    let point = src.find('~').unwrap();
+    let point = src.find('~').expect("Test input must contain a `~` character to represent cursor location");
     (point, src.replace('~', ""))
 }
 
@@ -190,7 +190,17 @@ fn get_definition(src: &str, dir: Option<TmpDir>) -> Match {
     let cache = racer::FileCache::default();
     let session = racer::Session::new(&cache);
 
-    find_definition(&path, completion_point, &session).unwrap()
+    find_definition(&path, completion_point, &session).expect("find-definition must produce a definition")
+}
+
+fn get_type(src: &str, dir: Option<TmpDir>) -> Match {
+    let dir = dir.unwrap_or_else(|| TmpDir::new());
+    let (search_point, clean_src) = get_pos_and_source(src);
+    let path = dir.write_file("src.rs", &clean_src);
+    let cache = racer::FileCache::default();
+    let session = racer::Session::new(&cache);
+
+    racer::get_type(&path, search_point, &session).expect("get-type must produce a type")
 }
 
 
@@ -3045,4 +3055,151 @@ fn closure_bracket_scope_nested_match_outside() {
     let got = get_definition(src, None);
     assert_eq!("x", got.matchstr);
     assert_eq!("| x: i32 |", got.contextstr);
+}
+
+#[test]
+fn get_type_finds_explicit_local_var() {
+    let _lock = sync!();
+    let src = "
+    fn main() {
+        let value: Option<u16> = Some(5);
+        if val~ue.is_some() {
+            // do nothing
+        }
+    }
+    ";
+
+    let got = get_type(src, None);
+    assert_eq!("Option", got.matchstr);
+}
+
+#[test]
+fn get_type_finds_fn_arg() {
+    let _lock = sync!();
+    let src = r#"
+    fn say_hello(name: &str) {
+        if nam~e != "teddriggs" {
+            // do nothing
+        }
+    }
+    "#;
+
+    let got = get_type(src, None);
+    assert_eq!("str", got.matchstr);
+}
+
+#[test]
+fn get_type_finds_tuple_field() {
+    let _lock = sync!();
+    let src = "
+    struct Bar;
+    struct Foo(Bar);
+
+    fn do_things(foo: Foo) -> Bar {
+        foo.0~
+    }
+    ";
+
+    let got = get_type(src, None);
+    assert_eq!("Bar", got.matchstr);
+}
+
+#[test]
+fn get_type_finds_struct_field() {
+    let _lock = sync!();
+    let src = "
+    struct Bar;
+    struct Foo { value: Bar }
+
+    fn do_things(foo: Foo) -> Bar {
+        foo.va~lue
+    }
+    ";
+
+    let got = get_type(src, None);
+    assert_eq!("Bar", got.matchstr);
+}
+
+#[test]
+fn get_type_finds_destructured() {
+    let _lock = sync!();
+    let src = "
+    struct Bar;
+    struct Foo { value: Bar }
+
+    fn do_things(foo: Foo) -> Bar {
+        let Foo { value: value } = foo;
+        valu~e
+    }
+    ";
+
+    let got = get_type(src, None);
+    assert_eq!("Bar", got.matchstr);
+}
+
+#[test]
+fn get_type_finds_single_character_var_at_end() {
+    let _lock = sync!();
+    let src = "
+    struct Bar;
+    fn do_things(y: Bar) -> Bar {
+        y~
+    }
+    ";
+
+    let got = get_type(src, None);
+    assert_eq!("Bar", got.matchstr);
+}
+
+#[test]
+fn get_type_finds_single_character_var_at_start() {
+    let _lock = sync!();
+    let src = "
+    struct Bar;
+    fn do_things(y: Bar) -> Bar {
+        ~y
+    }
+    ";
+
+    let got = get_type(src, None);
+    assert_eq!("Bar", got.matchstr);
+}
+
+#[test]
+fn get_type_finds_function_return() {
+    let _lock = sync!();
+    let src = r#"
+    struct Bar;
+    fn do_things(y: Bar) -> Bar {
+        y
+    }
+
+    fn main() {
+        let z = do_things();
+        println!("{:?}", ~z);
+    }
+    "#;
+
+    let got = get_type(src, None);
+    assert_eq!("Bar", got.matchstr);
+}
+
+#[test]
+fn get_type_finds_function() {
+    let _lock = sync!();
+    let src = r#"
+    struct Bar;
+    
+    fn do_things(y: Bar) -> Bar {
+        y
+    }
+
+    fn main() {
+        let z = do_th~ings();
+        println!("{:?}", ~z);
+    }
+    "#;
+
+    let got = get_type(src, None);
+    assert_eq!("do_things", got.matchstr);
 }


### PR DESCRIPTION
The `get-type` command (requested in #620) takes a line and character number which point to a complete identifier in the input text. The command will then attempt to determine the concrete type of that identifier.

Note that this also includes the travis updates from #728; this was necessary to make CI pass. 